### PR TITLE
Set installed addons for exclusion from extensions feed

### DIFF
--- a/includes/admin/add-ons.php
+++ b/includes/admin/add-ons.php
@@ -81,6 +81,27 @@ function edd_add_ons_get_feed( $tab = 'popular' ) {
 			$url = add_query_arg( array( 'display' => $tab ), $url );
 		}
 
+		// Get all installed plugins
+		$plugins = get_plugins();
+		$edd_addons = array();
+		if ( is_array( $plugins ) ) {
+			foreach ( $plugins as $plugin => $data ) {
+				// If it is an EDD extension, add it to an array
+				if ( strrpos( $plugin, 'edd' ) ) {
+					$trim = strlen( $plugin ) - strcspn( $plugin, '/' );
+					$string = substr( $plugin, 0, - $trim );
+					$edd_addons[] = $string;
+				}
+			}
+		}
+		// Convert the array to a comma separated list of strings
+		$edd_addons = implode( ',', $edd_addons );
+
+		// Add the directory names for each EDD extension that is installed to the 'exclude' query arg
+		if ( $edd_addons ) {
+			$url = add_query_arg( array( 'exclude' => $edd_addons ), $url );
+		}
+		
 		$feed = wp_remote_get( esc_url_raw( $url ), array( 'sslverify' => false ) );
 
 		if ( ! is_wp_error( $feed ) ) {

--- a/includes/admin/add-ons.php
+++ b/includes/admin/add-ons.php
@@ -107,7 +107,7 @@ function edd_add_ons_get_feed( $tab = 'popular' ) {
 		if ( ! is_wp_error( $feed ) ) {
 			if ( isset( $feed['body'] ) && strlen( $feed['body'] ) > 0 ) {
 				$cache = wp_remote_retrieve_body( $feed );
-				set_transient( 'easydigitaldownloads_add_ons_feed_' . $tab, $cache, 3600 );
+				set_transient( 'easydigitaldownloads_add_ons_feed_' . $tab, $cache, DAY_IN_SECONDS * 2 );
 			}
 		} else {
 			$cache = '<div class="error"><p>' . __( 'There was an error retrieving the extensions list from the server. Please try again later.', 'easy-digital-downloads' ) . '</div>';


### PR DESCRIPTION
This appends the names of the installed EDD addons to the feed URL so customers don't see extensions which they already have in the feed. Resolves #3733 and requires branch `issue/887` on EDD_Site to be merged.
