### PR TITLE
Allow rows/cols attributes on textarea setting fields to be customised

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1863,8 +1863,10 @@ function edd_textarea_callback( $args ) {
 	}
 
 	$class = edd_sanitize_html_class( $args['field_class'] );
+	$rows = isset( $args['rows'] ) ? (int) $args['rows'] : 5;
+	$cols = isset( $args['cols'] ) ? (int) $args['cols'] : 50;
 
-	$html = '<textarea class="' . $class . ' large-text" cols="50" rows="5" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']">' . esc_textarea( stripslashes( $value ) ) . '</textarea>';
+	$html = '<textarea class="' . $class . ' large-text" cols="' . esc_attr( $cols ) . '" rows="' . esc_attr( $rows ) . '" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']">' . esc_textarea( stripslashes( $value ) ) . '</textarea>';
 	$html .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"> '  . wp_kses_post( $args['desc'] ) . '</label>';
 
 	echo apply_filters( 'edd_after_setting_output', $html, $args );


### PR DESCRIPTION
Currently, if you add a textarea setting that uses edd_textarea_callback() then the rows/cols attributes on the output textarea are hardcoded to 5/50 respectively. This PR leaves those as defaults, but also allows them to be overriden when adding the setting field, e.g.

```php
add_settings_field(
	'edd_settings[my_field]',
        'field description'
	'edd_textarea_callback',
	'edd_settings_my_fieldset_main',
	'edd_settings_my_fieldset_main',
	[
		'id'   => 'my_field',
		'name' => 'field description',
		'desc' => 'field long description'
		'type' => 'textarea',
		'rows' => 16,
                'cols' => 80,
	]
);
```