### PR TITLE
Fix redundant action text on repeatable rows

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -440,7 +440,12 @@ function edd_render_price_row( $key, $args = array(), $post_id, $index ) {
 			$actions['show_advanced'] = '<a href="#" class="toggle-custom-price-option-section">' . __( 'Show advanced settings', 'easy-digital-downloads' ) . '</a>';
 		}
 
-		$actions['remove'] = '<a class="edd-remove-row edd-delete" data-type="price">' . sprintf( __( 'Remove', 'easy-digital-downloads' ), $key ) . '<span class="screen-reader-text"> ' . sprintf( __( 'price option %s', 'easy-digital-downloads' ), $key ) . '</span></a>';
+		$actions['remove'] = sprintf(
+			'<a aria-label="%s" class="edd-remove-row edd-delete" data-type="price">%s</a>',
+			/* translators: %s: download price option */
+			sprintf( __( 'Remove price option %s', 'easy-digital-downloads' ), $key ),
+			__( 'Remove', 'easy-digital-downloads' )
+		);
 		?>
 		<span class="edd-repeatable-row-actions">
 			<?php echo implode( '&nbsp;&#124;&nbsp;', $actions ); ?>
@@ -646,7 +651,14 @@ function edd_render_products_field( $post_id ) {
 										?>
 									</div>
 									<span class="edd-bundled-product-actions">
-										<a class="edd-remove-row edd-delete" data-type="file"><?php printf( __( 'Remove', 'easy-digital-downloads' ), $index ); ?><span class="screen-reader-text"> <?php printf( __( 'bundle option %s', 'easy-digital-downloads' ), $index ); ?></span></a>
+									<?php
+									printf(
+										'<a aria-label="%s" class="edd-remove-row edd-delete" data-type="file">%s</a>',
+										/* translators: %s: download bundle option */
+										sprintf( esc_html__( 'Remove bundle option %s', 'easy-digital-downloads' ), $key ),
+										esc_html__( 'Remove', 'easy-digital-downloads' )
+									);
+									?>
 									</span>
 									<?php do_action( 'edd_download_products_table_row', $post_id ); ?>
 								</div>
@@ -702,7 +714,13 @@ function edd_render_products_field( $post_id ) {
 									?>
 								</div>
 								<span class="edd-bundled-product-actions">
-									<a class="edd-remove-row edd-delete" data-type="file" ><?php printf( __( 'Remove', 'easy-digital-downloads' ) ); ?><span class="screen-reader-text"> <?php __( 'bundle option 1', 'easy-digital-downloads' ); ?></span></a>
+								<?php
+								printf(
+									'<a aria-label="%s" class="edd-remove-row edd-delete" data-type="file">%s</a>',
+									esc_html__( 'Remove bundle option 1', 'easy-digital-downloads' ),
+									esc_html__( 'Remove', 'easy-digital-downloads' )
+								);
+								?>
 								</span>
 								<?php do_action( 'edd_download_products_table_row', $post_id ); ?>
 							</div>
@@ -827,8 +845,14 @@ function edd_render_file_row( $key = '', $args = array(), $post_id, $index ) {
 			<input type="hidden" name="edd_download_files[<?php echo $key; ?>][index]" class="edd_repeatable_index" value="<?php echo $index; ?>"/>
 		</span>
 		<span class="edd-repeatable-row-actions">
-			<a class="edd-remove-row edd-delete" data-type="file"><?php printf( __( 'Remove', 'easy-digital-downloads' ), $key ); ?><span class="screen-reader-text"> <?php printf( __( 'file %s', 'easy-digital-downloads' ), $key ); ?></span>
-			</a>
+		<?php
+		printf(
+			'<a aria-label="%s" class="edd-remove-row edd-delete" data-type="file">%s</a>',
+			/* translators: %s: download file */
+			sprintf( esc_html__( 'Remove file %s', 'easy-digital-downloads' ), $key ),
+			esc_html__( 'Remove', 'easy-digital-downloads' )
+		);
+		?>
 		</span>
 	</div>
 

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -440,7 +440,7 @@ function edd_render_price_row( $key, $args = array(), $post_id, $index ) {
 			$actions['show_advanced'] = '<a href="#" class="toggle-custom-price-option-section">' . __( 'Show advanced settings', 'easy-digital-downloads' ) . '</a>';
 		}
 
-		$actions['remove'] = '<a class="edd-remove-row edd-delete" data-type="price">' . sprintf( __( 'Remove', 'easy-digital-downloads' ), $key ) . '<span class="screen-reader-text">' . sprintf( __( 'Remove price option %s', 'easy-digital-downloads' ), $key ) . '</span></a>';
+		$actions['remove'] = '<a class="edd-remove-row edd-delete" data-type="price">' . sprintf( __( 'Remove', 'easy-digital-downloads' ), $key ) . '<span class="screen-reader-text"> ' . sprintf( __( 'price option %s', 'easy-digital-downloads' ), $key ) . '</span></a>';
 		?>
 		<span class="edd-repeatable-row-actions">
 			<?php echo implode( '&nbsp;&#124;&nbsp;', $actions ); ?>
@@ -646,7 +646,7 @@ function edd_render_products_field( $post_id ) {
 										?>
 									</div>
 									<span class="edd-bundled-product-actions">
-										<a class="edd-remove-row edd-delete" data-type="file"><?php printf( __( 'Remove', 'easy-digital-downloads' ), $index ); ?><span class="screen-reader-text"><?php printf( __( 'Remove bundle option %s', 'easy-digital-downloads' ), $index ); ?></span></a>
+										<a class="edd-remove-row edd-delete" data-type="file"><?php printf( __( 'Remove', 'easy-digital-downloads' ), $index ); ?><span class="screen-reader-text"> <?php printf( __( 'bundle option %s', 'easy-digital-downloads' ), $index ); ?></span></a>
 									</span>
 									<?php do_action( 'edd_download_products_table_row', $post_id ); ?>
 								</div>
@@ -702,7 +702,7 @@ function edd_render_products_field( $post_id ) {
 									?>
 								</div>
 								<span class="edd-bundled-product-actions">
-									<a class="edd-remove-row edd-delete" data-type="file" ><?php printf( __( 'Remove', 'easy-digital-downloads' ) ); ?><span class="screen-reader-text"><?php __( 'Remove bundle option 1', 'easy-digital-downloads' ); ?></span></a>
+									<a class="edd-remove-row edd-delete" data-type="file" ><?php printf( __( 'Remove', 'easy-digital-downloads' ) ); ?><span class="screen-reader-text"> <?php __( 'bundle option 1', 'easy-digital-downloads' ); ?></span></a>
 								</span>
 								<?php do_action( 'edd_download_products_table_row', $post_id ); ?>
 							</div>
@@ -827,7 +827,7 @@ function edd_render_file_row( $key = '', $args = array(), $post_id, $index ) {
 			<input type="hidden" name="edd_download_files[<?php echo $key; ?>][index]" class="edd_repeatable_index" value="<?php echo $index; ?>"/>
 		</span>
 		<span class="edd-repeatable-row-actions">
-			<a class="edd-remove-row edd-delete" data-type="file"><?php printf( __( 'Remove', 'easy-digital-downloads' ), $key ); ?><span class="screen-reader-text"><?php printf( __( 'Remove file %s', 'easy-digital-downloads' ), $key ); ?></span>
+			<a class="edd-remove-row edd-delete" data-type="file"><?php printf( __( 'Remove', 'easy-digital-downloads' ), $key ); ?><span class="screen-reader-text"> <?php printf( __( 'file %s', 'easy-digital-downloads' ), $key ); ?></span>
 			</a>
 		</span>
 	</div>

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -443,8 +443,8 @@ function edd_render_price_row( $key, $args = array(), $post_id, $index ) {
 		$actions['remove'] = sprintf(
 			'<a aria-label="%s" class="edd-remove-row edd-delete" data-type="price">%s</a>',
 			/* translators: %s: download price option */
-			sprintf( __( 'Remove price option %s', 'easy-digital-downloads' ), $key ),
-			__( 'Remove', 'easy-digital-downloads' )
+			esc_attr( sprintf( __( 'Remove price option %s', 'easy-digital-downloads' ), $key ) ),
+			esc_html__( 'Remove', 'easy-digital-downloads' )
 		);
 		?>
 		<span class="edd-repeatable-row-actions">
@@ -655,7 +655,7 @@ function edd_render_products_field( $post_id ) {
 									printf(
 										'<a aria-label="%s" class="edd-remove-row edd-delete" data-type="file">%s</a>',
 										/* translators: %s: download bundle option */
-										sprintf( esc_html__( 'Remove bundle option %s', 'easy-digital-downloads' ), $key ),
+										esc_attr( sprintf( __( 'Remove bundle option %s', 'easy-digital-downloads' ), $key ) ),
 										esc_html__( 'Remove', 'easy-digital-downloads' )
 									);
 									?>
@@ -717,7 +717,7 @@ function edd_render_products_field( $post_id ) {
 								<?php
 								printf(
 									'<a aria-label="%s" class="edd-remove-row edd-delete" data-type="file">%s</a>',
-									esc_html__( 'Remove bundle option 1', 'easy-digital-downloads' ),
+									esc_attr__( 'Remove bundle option 1', 'easy-digital-downloads' ),
 									esc_html__( 'Remove', 'easy-digital-downloads' )
 								);
 								?>
@@ -849,7 +849,7 @@ function edd_render_file_row( $key = '', $args = array(), $post_id, $index ) {
 		printf(
 			'<a aria-label="%s" class="edd-remove-row edd-delete" data-type="file">%s</a>',
 			/* translators: %s: download file */
-			sprintf( esc_html__( 'Remove file %s', 'easy-digital-downloads' ), $key ),
+			esc_attr( sprintf( __( 'Remove file %s', 'easy-digital-downloads' ), $key ) ),
 			esc_html__( 'Remove', 'easy-digital-downloads' )
 		);
 		?>

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -442,8 +442,7 @@ function edd_render_price_row( $key, $args = array(), $post_id, $index ) {
 
 		$actions['remove'] = sprintf(
 			'<a aria-label="%s" class="edd-remove-row edd-delete" data-type="price">%s</a>',
-			/* translators: %s: download price option */
-			esc_attr( sprintf( __( 'Remove price option %s', 'easy-digital-downloads' ), $key ) ),
+			esc_attr__( 'Remove price option', 'easy-digital-downloads' ),
 			esc_html__( 'Remove', 'easy-digital-downloads' )
 		);
 		?>
@@ -654,8 +653,7 @@ function edd_render_products_field( $post_id ) {
 									<?php
 									printf(
 										'<a aria-label="%s" class="edd-remove-row edd-delete" data-type="file">%s</a>',
-										/* translators: %s: download bundle option */
-										esc_attr( sprintf( __( 'Remove bundle option %s', 'easy-digital-downloads' ), $key ) ),
+										esc_attr__( 'Remove bundle option', 'easy-digital-downloads' ),
 										esc_html__( 'Remove', 'easy-digital-downloads' )
 									);
 									?>
@@ -717,7 +715,7 @@ function edd_render_products_field( $post_id ) {
 								<?php
 								printf(
 									'<a aria-label="%s" class="edd-remove-row edd-delete" data-type="file">%s</a>',
-									esc_attr__( 'Remove bundle option 1', 'easy-digital-downloads' ),
+									esc_attr__( 'Remove bundle option', 'easy-digital-downloads' ),
 									esc_html__( 'Remove', 'easy-digital-downloads' )
 								);
 								?>
@@ -848,8 +846,7 @@ function edd_render_file_row( $key = '', $args = array(), $post_id, $index ) {
 		<?php
 		printf(
 			'<a aria-label="%s" class="edd-remove-row edd-delete" data-type="file">%s</a>',
-			/* translators: %s: download file */
-			esc_attr( sprintf( __( 'Remove file %s', 'easy-digital-downloads' ), $key ) ),
+			esc_attr__( 'Remove file', 'easy-digital-downloads' ),
 			esc_html__( 'Remove', 'easy-digital-downloads' )
 		);
 		?>


### PR DESCRIPTION
Removes extra "remove" from the screen-reader-text in repeatable row actions.

Fixes #7702 