### PR TITLE
Update edd_is_dev_environment to use wp_get_environment_type

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -80,20 +80,19 @@ function edd_is_debug_mode() {
  *
  * @since 3.0
  *
- * @return bool|string $retval False if not a development environment, otherwise string matching environment, port, or domain.
+ * @return bool $is_dev_environment True if development environment; otherwise false.
  */
 function edd_is_dev_environment() {
 
 	// wp_get_environment_type was added in WordPress 5.5.
 	if ( function_exists( 'wp_get_environment_type' ) ) {
 		$environment = wp_get_environment_type();
-		if ( in_array( $environment, array( 'local', 'development' ), true ) ) {
-			return apply_filters( 'edd_is_dev_environment', $environment );
-		}
+
+		return apply_filters( 'edd_is_dev_environment', in_array( $environment, array( 'local', 'development' ), true ) );
 	}
 
 	// Assume not a development environment
-	$retval = false;
+	$is_dev_environment = false;
 
 	// Get this one time and use it below
 	$network_url = network_site_url( '/' );
@@ -123,13 +122,13 @@ function edd_is_dev_environment() {
 	// Loop through all strings
 	foreach ( $strings as $string ) {
 		if ( stristr( $network_url, $string ) ) {
-			$retval = $string;
+			$is_dev_environment = true;
 			break;
 		}
 	}
 
 	// Filter & return
-	return apply_filters( 'edd_is_dev_environment', $retval );
+	return apply_filters( 'edd_is_dev_environment', $is_dev_environment );
 }
 
 /**

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -80,9 +80,17 @@ function edd_is_debug_mode() {
  *
  * @since 3.0
  *
- * @return bool $retval True if dev, false if not.
+ * @return bool|string $retval False if not a development environment, otherwise string matching environment, port, or domain.
  */
 function edd_is_dev_environment() {
+
+	// wp_get_environment_type was added in WordPress 5.5.
+	if ( function_exists( 'wp_get_environment_type' ) ) {
+		$environment = wp_get_environment_type();
+		if ( in_array( $environment, array( 'local', 'development' ), true ) ) {
+			return apply_filters( 'edd_is_dev_environment', $environment );
+		}
+	}
 
 	// Assume not a development environment
 	$retval = false;


### PR DESCRIPTION
Fixes #8913

Proposed Changes:
1. If `wp_get_environment_type` exists, use that to check if the current site is a development site. This function returns one of `'local'`, `'development'`, `'staging'`, or`'production'`. If the environment is `local` or `development`, this is considered to be true and returns early, instead of sorting through the URL options.
2. Updates the doc block return value, as this function actually returns either false or a string, matching whatever was determined to be the determining condition.