### PR TITLE
Ensure file URL creation and validation use the same arary of parameters

### DIFF
--- a/includes/deprecated-functions.php
+++ b/includes/deprecated-functions.php
@@ -993,3 +993,34 @@ function maybe_add_jilt_notice_to_abandoned_payment( $payment_id ) {
 		<?php
 	}
 }
+
+/**
+ * Reverts to the original download URL validation.
+ *
+ * @since 2.11.3
+ * @todo  Remove this function in 3.0.
+ *
+ * @param bool   $ret
+ * @param string $url
+ * @param array  $query_args
+ * @param string $original_url
+ */
+add_filter( 'edd_validate_url_token', function( $ret, $url, $query_args, $original_url ) {
+	// If the URL is already validated, we don't need to validate it again.
+	if ( $ret ) {
+		return $ret;
+	}
+	$allowed = edd_get_url_token_parameters();
+	$remove  = array();
+	foreach ( $query_args as $key => $value ) {
+		if ( ! in_array( $key, $allowed, true ) ) {
+			$remove[] = $key;
+		}
+	}
+
+	if ( ! empty( $remove ) ) {
+		$original_url = remove_query_arg( $remove, $original_url );
+	}
+
+	return isset( $query_args['token'] ) && hash_equals( $query_args['token'], edd_get_download_token( $original_url ) );
+}, 10, 4 );

--- a/includes/deprecated-functions.php
+++ b/includes/deprecated-functions.php
@@ -997,7 +997,7 @@ function maybe_add_jilt_notice_to_abandoned_payment( $payment_id ) {
 /**
  * Reverts to the original download URL validation.
  *
- * @since 2.11.3
+ * @since 2.11.4
  * @todo  Remove this function in 3.0.
  *
  * @param bool   $ret

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1260,8 +1260,10 @@ function edd_get_download_token( $url = '' ) {
  */
 function edd_validate_url_token( $url = '' ) {
 
-	$ret   = false;
-	$parts = parse_url( $url );
+	$ret          = false;
+	$parts        = parse_url( $url );
+	$query_args   = array();
+	$original_url = $url;
 
 	if ( isset( $parts['query'] ) ) {
 
@@ -1285,9 +1287,6 @@ function edd_validate_url_token( $url = '' ) {
 				$validated_query_args[ $key ] = $query_args[ $key ];
 			}
 		}
-
-		// Save the original URL for the filter.
-		$original_url = $url;
 
 		// strtok allows a quick clearing of existing query string parameters, so we can re-add the allowed ones.
 		$url = add_query_arg( $validated_query_args, strtok( $url, '?' ) );

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1034,10 +1034,7 @@ function edd_get_download_file_url( $key, $email, $filekey, $download_id = 0, $p
 	if ( ! empty( $payment->ID ) ) {
 
 		// Get the array of parameters in the same order in which they will be validated.
-		$parameters = edd_get_url_token_parameters();
-		foreach ( $parameters as $parameter ) {
-			$args[ $parameter ] = '';
-		}
+		$args = array_fill_keys( edd_get_url_token_parameters(), '' );
 
 		// Simply the URL by concatenating required data using a colon as a delimiter.
 		$args['eddfile'] = rawurlencode( sprintf( '%d:%d:%d:%d', $payment->ID, $params['download_id'], $params['file'], $price_id ) );

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1049,10 +1049,10 @@ function edd_get_download_file_url( $key, $email, $filekey, $download_id = 0, $p
 		$args = apply_filters( 'edd_get_download_file_url_args', $args, $payment->ID, $params );
 
 		$args['file']  = $params['file'];
-		$args['token'] = edd_get_download_token( add_query_arg( $args, untrailingslashit( site_url() ) ) );
+		$args['token'] = edd_get_download_token( add_query_arg( array_filter( $args ), untrailingslashit( site_url() ) ) );
 	}
 
-	return add_query_arg( $args, site_url( 'index.php' ) );
+	return add_query_arg( array_filter( $args ), site_url( 'index.php' ) );
 }
 
 /**

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1289,18 +1289,25 @@ function edd_validate_url_token( $url = '' ) {
 			}
 		}
 
+		$original_url = $url;
+
 		// strtok allows a quick clearing of existing query string parameters, so we can re-add the allowed ones.
 		$url = add_query_arg( $allowed_args, strtok( $url, '?' ) );
 
 		if ( isset( $query_args['token'] ) && hash_equals( $query_args['token'], edd_get_download_token( $url ) ) ) {
-
 			$ret = true;
-
 		}
-
 	}
 
-	return apply_filters( 'edd_validate_url_token', $ret, $url, $query_args );
+	/**
+	 * Filters the URL token validation.
+	 *
+	 * @param bool   $ret          Whether the URL has validated or not.
+	 * @param string $url          The URL used for validation.
+	 * @param array  $query_args   The array of query parameters.
+	 * @param string $original_url The original URL (added 2.11.3).
+	 */
+	return apply_filters( 'edd_validate_url_token', $ret, $url, $query_args, $original_url );
 }
 
 /**

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1275,21 +1275,22 @@ function edd_validate_url_token( $url = '' ) {
 		}
 
 		// These are the only URL parameters that are allowed to affect the token validation.
-		$allowed = edd_get_url_token_parameters();
+		$allowed_args = edd_get_url_token_parameters();
 
 		// Collect the allowed tags in proper order, remove all tags, and re-add only the allowed ones.
-		$allowed_args = array();
+		$validated_query_args = array();
 
-		foreach ( $allowed as $key ) {
+		foreach ( $allowed_args as $key ) {
 			if ( true === array_key_exists( $key, $query_args ) ) {
-				$allowed_args[ $key ] = $query_args[ $key ];
+				$validated_query_args[ $key ] = $query_args[ $key ];
 			}
 		}
 
+		// Save the original URL for the filter.
 		$original_url = $url;
 
 		// strtok allows a quick clearing of existing query string parameters, so we can re-add the allowed ones.
-		$url = add_query_arg( $allowed_args, strtok( $url, '?' ) );
+		$url = add_query_arg( $validated_query_args, strtok( $url, '?' ) );
 
 		if ( isset( $query_args['token'] ) && hash_equals( $query_args['token'], edd_get_download_token( $url ) ) ) {
 			$ret = true;

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1059,7 +1059,7 @@ function edd_get_download_file_url( $key, $email, $filekey, $download_id = 0, $p
  * Gets the array of parameters to be used for the URL token generation and validation.
  * Used by `edd_get_download_file_url` and `edd_validate_url_token` so that their parameters are ordered the same.
  *
- * @since 2.11.3
+ * @since 2.11.4
  * @return array
  */
 function edd_get_url_token_parameters() {

--- a/tests/tests-process-dowload.php
+++ b/tests/tests-process-dowload.php
@@ -65,4 +65,27 @@ class Tests_Process_Download extends EDD_UnitTestCase {
 
 		$this->assertTrue( edd_validate_url_token( $url ) );
 	}
+
+	public function test_custom_parameters() {
+
+		$payment_id = EDD_Helper_Payment::create_simple_payment();
+		$payment    = edd_get_payment( $payment_id );
+		$download   = EDD_Helper_Download::create_simple_download();
+
+		add_filter( 'edd_get_download_file_url_args', function ( $args, $payment_id, $params ) {
+			$args['beta'] = 1;
+
+			return $args;
+		}, 10, 3 );
+
+		add_filter( 'edd_url_token_allowed_params', function ( $args ) {
+			$args[] = 'beta';
+
+			return $args;
+		} );
+
+		$url = edd_get_download_file_url( $payment->key, $payment->email, '', $download->ID );
+
+		$this->assertTrue( edd_validate_url_token( $url ) );
+	}
 }

--- a/tests/tests-process-dowload.php
+++ b/tests/tests-process-dowload.php
@@ -84,7 +84,9 @@ class Tests_Process_Download extends EDD_UnitTestCase {
 			return $args;
 		} );
 
-		$url = edd_get_download_file_url( $payment->key, $payment->email, '', $download->ID );
+		$parts = parse_url( add_query_arg( array(), edd_get_download_file_url( $payment->key, $payment->email, '', $download->ID ) ) );
+		wp_parse_str( $parts['query'], $query_args );
+		$url = add_query_arg( $query_args, site_url() );
 
 		$this->assertTrue( edd_validate_url_token( $url ) );
 	}


### PR DESCRIPTION
Fixes #8917

Based on a discussion with @cklosowski I'm putting together this draft PR to see how it does. The issue, I think, is that we have the download URL being built off of one array, and validated off of another array, and the order now matters. However, since two different filters/functions/filters are involved, the problem is that the two arrays can be disordered/out of sync with each other.

Proposed Changes:
1. Creates a new function, `edd_get_url_token_parameters`, which returns a one dimensional array of the URL parameters which are allowed for URL validation.
2. That array is replaced 1:1 in `edd_validate_url_token`.
3. The same array is now used as the base array in `edd_get_download_file_url` and populated with empty values, so that the initial array order is set to match the validation array, and then the rest of the function fills in array values as previously done.

What this does not fix: links which would have been sent out via email in which the parameters are in a different order. One thought I had was to add back the original code (prior to 2.11.2), to run that at the end of the validation if `$ret` ended up still being false. So ideally, everything would be in order, but if it's not, possibly it could still validate.

Tested locally and with the fix, the dynamically generated file URL is:
```
https://edd.local/index.php?eddfile=614%3A35%3A1%3A1&ttl=1633794013&file=1&token=262cfc100cea02545ff705a7f447898d3fd60ca79e142f52bd5d188aae68ad09&beta=1
```

The link generated by EDD 2.11.2 does not validate with this fix or in 2.11.2:
```
https://edd.local/index.php?eddfile=614%3A35%3A1%3A1&ttl=1633793963&beta=1&file=1&token=8a38bbf5aed7deff5cf7e0a93b1a5c38a2b1306f544383b799ffbffbda6dde6d
```

The filters I used, based on the information in the linked issue:
```php
add_filter( 'edd_get_download_file_url_args', 'filter_edd_get_download_file_url_args', 10, 3 );
function filter_edd_get_download_file_url_args( $args, $payment_id, $params ) {
	if ( ! empty( $params['download_id'] )
		&& 35 === (int) $params['download_id'] ) { // 35 is my download ID
		$args['beta'] = 1;
	}
	return $args;
}

add_filter( 'edd_url_token_allowed_params', 'filter_edd_url_token_allowed_params' );
function filter_edd_url_token_allowed_params( $args ) {
	$args[] = 'beta';

	return $args;
}
```

Marking as draft for review/discussion.