### PR TITLE
Check if _edd_log_ip is set before using

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -243,7 +243,7 @@ class Data_Migrator {
 				'order_id'      => isset( $post_meta['_edd_log_payment_id'] )  ? $post_meta['_edd_log_payment_id']  : 0,
 				'price_id'      => isset( $post_meta['_edd_log_price_id'] )    ? $post_meta['_edd_log_price_id']    : 0,
 				'customer_id'   => isset( $post_meta['_edd_log_customer_id'] ) ? $post_meta['_edd_log_customer_id'] : 0,
-				'ip'            => $post_meta['_edd_log_ip'],
+				'ip'            => isset( $post_meta['_edd_log_ip'] ) ? $post_meta['_edd_log_ip'] : '',
 				'date_created'  => $data->post_date_gmt,
 				'date_modified' => $data->post_modified_gmt,
 			);

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -713,6 +713,9 @@ class Data_Migrator {
 		 */
 		$order_data = apply_filters( 'edd_30_migration_order_creation_data', $order_data, $payment_meta, $cart_details, $meta );
 
+		// Remove all order status transition actions.
+		remove_all_actions( 'edd_transition_order_status' );
+
 		$order_id = edd_add_order( $order_data );
 
 		// Save an un-matched tax rate in order meta.


### PR DESCRIPTION
Fixes #8933

Proposed Changes:
1. Add `isset( $post_meta['_edd_log_ip'] )` before using it in the migration.
