### PR TITLE
Fix PHP parser error in contextual-help.php files

### DIFF
--- a/includes/admin/discounts/contextual-help.php
+++ b/includes/admin/discounts/contextual-help.php
@@ -22,11 +22,11 @@ function edd_discounts_contextual_help() {
 	$screen = get_current_screen();
 
 	$screen->set_help_sidebar(
-		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) ) . '</p>' .
+		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) ) . '</strong></p>' .
+		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) . '</p>' .
 		'<p>' . sprintf(
 			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
-			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' ),
+			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
 		) . '</p>'
 	);
 

--- a/includes/admin/discounts/contextual-help.php
+++ b/includes/admin/discounts/contextual-help.php
@@ -22,7 +22,7 @@ function edd_discounts_contextual_help() {
 	$screen = get_current_screen();
 
 	$screen->set_help_sidebar(
-		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) ) . '</strong></p>' .
+		'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
 		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) . '</p>' .
 		'<p>' . sprintf(
 			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),

--- a/includes/admin/downloads/contextual-help.php
+++ b/includes/admin/downloads/contextual-help.php
@@ -25,7 +25,7 @@ function edd_downloads_contextual_help() {
 		return;
 
 	$screen->set_help_sidebar(
-		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) ) . '</strong></p>' .
+		'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
 		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) . '</p>' .
 		'<p>' . sprintf(
 			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),

--- a/includes/admin/downloads/contextual-help.php
+++ b/includes/admin/downloads/contextual-help.php
@@ -25,11 +25,11 @@ function edd_downloads_contextual_help() {
 		return;
 
 	$screen->set_help_sidebar(
-		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) ) . '</p>' .
+		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) ) . '</strong></p>' .
+		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) . '</p>' .
 		'<p>' . sprintf(
 			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
-			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' ),
+			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
 		) . '</p>'
 	);
 

--- a/includes/admin/payments/contextual-help.php
+++ b/includes/admin/payments/contextual-help.php
@@ -26,11 +26,11 @@ function edd_payments_contextual_help() {
 		return;
 
 	$screen->set_help_sidebar(
-		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) ) . '</p>' .
+		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) ) . '</strong></p>' .
+		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) . '</p>' .
 		'<p>' . sprintf(
 			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
-			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' ),
+			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
 		) . '</p>'
 	);
 

--- a/includes/admin/payments/contextual-help.php
+++ b/includes/admin/payments/contextual-help.php
@@ -26,7 +26,7 @@ function edd_payments_contextual_help() {
 		return;
 
 	$screen->set_help_sidebar(
-		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) ) . '</strong></p>' .
+		'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
 		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) . '</p>' .
 		'<p>' . sprintf(
 			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),

--- a/includes/admin/reporting/contextual-help.php
+++ b/includes/admin/reporting/contextual-help.php
@@ -26,11 +26,11 @@ function edd_reporting_contextual_help() {
 		return;
 
 	$screen->set_help_sidebar(
-		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) ) . '</p>' .
+		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) ) . '</strong></p>' .
+		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) . '</p>' .
 		'<p>' . sprintf(
 			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
-			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' ),
+			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
 		) . '</p>'
 	);
 

--- a/includes/admin/reporting/contextual-help.php
+++ b/includes/admin/reporting/contextual-help.php
@@ -26,7 +26,7 @@ function edd_reporting_contextual_help() {
 		return;
 
 	$screen->set_help_sidebar(
-		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) ) . '</strong></p>' .
+		'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
 		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) . '</p>' .
 		'<p>' . sprintf(
 			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),

--- a/includes/admin/settings/contextual-help.php
+++ b/includes/admin/settings/contextual-help.php
@@ -26,11 +26,11 @@ function edd_settings_contextual_help() {
 		return;
 
 	$screen->set_help_sidebar(
-		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) ) . '</p>' .
+		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) ) . '</strong></p>' .
+		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) . '</p>' .
 		'<p>' . sprintf(
 			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now!</a>.', 'easy-digital-downloads' ),
-			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' ),
+			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
 		) . '</p>'
 	);
 

--- a/includes/admin/settings/contextual-help.php
+++ b/includes/admin/settings/contextual-help.php
@@ -26,7 +26,7 @@ function edd_settings_contextual_help() {
 		return;
 
 	$screen->set_help_sidebar(
-		'<p><strong>' . sprintf( __( 'For more information:', 'easy-digital-downloads' ) ) . '</strong></p>' .
+		'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
 		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'http://docs.easydigitaldownloads.com/' ) ) . '</p>' .
 		'<p>' . sprintf(
 			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now!</a>.', 'easy-digital-downloads' ),


### PR DESCRIPTION
Fixes #

Version: 2.11.3

Parse error broke my localhost:

```sh
[01-Nov-2021 11:38:26 UTC] PHP Parse error:  syntax error, unexpected ')' in /home/anna/html/wp58/wp-content/plugins/easy-digital-downloads/includes/admin/discounts/contextual-help.php on line 30
```

This error happens 5 times in these `contextual-help.php` files:

- `discounts`
- `downloads`
- `payments`
- `reporting`
- `settings`

Proposed Changes:
1. Fix parentheses

_Please do not submit PRs with minified CSS or JS files. This is managed at the time of release by the Core Team_
