### PR TITLE
Catch exceptions and return false #8965

### DIFF
--- a/includes/admin/class-pass-manager.php
+++ b/includes/admin/class-pass-manager.php
@@ -177,7 +177,11 @@ class Pass_Manager {
 	 * @return bool
 	 */
 	public function hasPersonalPass() {
-		return self::pass_compare( $this->highest_pass_id, self::PERSONAL_PASS_ID, '=' );
+		try {
+			return self::pass_compare( $this->highest_pass_id, self::PERSONAL_PASS_ID, '=' );
+		} catch ( \Exception $e ) {
+			return false;
+		}
 	}
 
 	/**
@@ -188,7 +192,11 @@ class Pass_Manager {
 	 * @return bool
 	 */
 	public function hasExtendedPass() {
-		return self::pass_compare( $this->highest_pass_id, self::EXTENDED_PASS_ID, '=' );
+		try {
+			return self::pass_compare( $this->highest_pass_id, self::EXTENDED_PASS_ID, '=' );
+		} catch ( \Exception $e ) {
+			return false;
+		}
 	}
 
 	/**
@@ -199,7 +207,11 @@ class Pass_Manager {
 	 * @return bool
 	 */
 	public function hasProfessionalPass() {
-		return self::pass_compare( $this->highest_pass_id, self::PROFESSIONAL_PASS_ID, '=' );
+		try {
+			return self::pass_compare( $this->highest_pass_id, self::PROFESSIONAL_PASS_ID, '=' );
+		} catch( \Exception $e ) {
+			return false;
+		}
 	}
 
 	/**
@@ -211,7 +223,11 @@ class Pass_Manager {
 	 * @return bool
 	 */
 	public function hasAllAccessPass() {
-		return self::pass_compare( $this->highest_pass_id, self::ALL_ACCESS_PASS_ID, '>=' );
+		try {
+			return self::pass_compare( $this->highest_pass_id, self::ALL_ACCESS_PASS_ID, '>=' );
+		} catch( \Exception $e ) {
+			return false;
+		}
 	}
 
 	/**

--- a/tests/tests-pass-manager.php
+++ b/tests/tests-pass-manager.php
@@ -115,4 +115,41 @@ class Pass_Manager extends \EDD_UnitTestCase {
 		$this->assertFalse( $manager->has_pass() );
 	}
 
+	/**
+	 * @covers \EDD\Admin\Pass_Manager::isFree
+	 */
+	public function test_site_with_no_licenses() {
+		$passManger = new \EDD\Admin\Pass_Manager();
+
+		$this->assertTrue( $passManger->isFree() );
+		$this->assertFalse( $passManger->hasPersonalPass() );
+		$this->assertFalse( $passManger->hasExtendedPass() );
+		$this->assertFalse( $passManger->hasProfessionalPass() );
+		$this->assertFalse( $passManger->hasAllAccessPass() );
+		$this->assertFalse( $passManger->has_pass() );
+	}
+
+	/**
+	 * @covers \EDD\Admin\Pass_Manager::hasPersonalPass
+	 */
+	public function test_site_with_personal_pass() {
+		$passes = array(
+			'license_1' => array(
+				'pass_id'      => \EDD\Admin\Pass_Manager::PERSONAL_PASS_ID,
+				'time_checked' => time()
+			),
+		);
+
+		update_option( 'edd_pass_licenses', json_encode( $passes ) );
+
+		global $edd_licensed_products;
+		$edd_licensed_products[] = 'product';
+
+		$passManger = new \EDD\Admin\Pass_Manager();
+
+		$this->assertFalse( $passManger->isFree() );
+		$this->assertTrue( $passManger->hasPersonalPass() );
+		$this->assertTrue( $passManger->has_pass() );
+	}
+
 }


### PR DESCRIPTION
Fixes #8965

Proposed Changes:
1. Catch exceptions and return `false` if one occurs.
2. Add some more unit tests covering some of these methods.