### PR TITLE
Fix license upgrade display logic for EDD admin pages

### DIFF
--- a/includes/admin/promos/notices/class-license-upgrade-notice.php
+++ b/includes/admin/promos/notices/class-license-upgrade-notice.php
@@ -61,7 +61,7 @@ class License_Upgrade_Notice extends Notice {
 
 		$screen = get_current_screen();
 
-		if ( ! $screen instanceof \WP_Screen || 'dashboard' === $screen->id || ! edd_is_admin_page() ) {
+		if ( ! $screen instanceof \WP_Screen || 'dashboard' === $screen->id || ! edd_is_admin_page( '', '', false ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #8947

Proposed Changes:
1. Sets the `$include_non_exclusive` flag to false when evaluating `edd_is_admin_page` for the license upgrade notices.