### PR TITLE
Save $edd_licensed_products to options so it can be referenced outside WP-Admin #8969

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -278,6 +278,7 @@ final class Easy_Digital_Downloads {
 		require_once EDD_PLUGIN_DIR . 'includes/class-edd-roles.php';
 		require_once EDD_PLUGIN_DIR . 'includes/country-functions.php';
 		require_once EDD_PLUGIN_DIR . 'includes/formatting.php';
+		require_once EDD_PLUGIN_DIR . 'includes/licensing/licensing-functions.php';
 		require_once EDD_PLUGIN_DIR . 'includes/widgets.php';
 		require_once EDD_PLUGIN_DIR . 'includes/misc-functions.php';
 		require_once EDD_PLUGIN_DIR . 'includes/mime-types.php';

--- a/includes/admin/class-pass-manager.php
+++ b/includes/admin/class-pass-manager.php
@@ -83,11 +83,8 @@ class Pass_Manager {
 			$this->has_pass_data = true;
 		}
 
-		$this->highest_pass_id = $this->get_highest_pass_id();
-
-		global $edd_licensed_products;
-
-		$this->number_license_keys = is_array( $edd_licensed_products ) ? count( $edd_licensed_products ) : 0;
+		$this->highest_pass_id     = $this->get_highest_pass_id();
+		$this->number_license_keys = count( \EDD\Licensing\get_licensed_products() );
 	}
 
 	/**

--- a/includes/admin/class-pass-manager.php
+++ b/includes/admin/class-pass-manager.php
@@ -84,7 +84,7 @@ class Pass_Manager {
 		}
 
 		$this->highest_pass_id     = $this->get_highest_pass_id();
-		$this->number_license_keys = count( \EDD\Licensing\get_licensed_products() );
+		$this->number_license_keys = count( \EDD\Licensing\get_licensed_extension_slugs() );
 	}
 
 	/**

--- a/includes/class-edd-license-handler.php
+++ b/includes/class-edd-license-handler.php
@@ -364,7 +364,7 @@ class EDD_License {
 
 		// Clear the option for licensed extensions to force regeneration.
 		if ( ! empty( $api_data->license ) && 'valid' === $api_data->license ) {
-			delete_option( 'edd_licensed_products' );
+			delete_option( 'edd_licensed_extensions' );
 		}
 
 		update_option( $this->item_shortname . '_license_active', $license_data );

--- a/includes/class-edd-license-handler.php
+++ b/includes/class-edd-license-handler.php
@@ -362,6 +362,11 @@ class EDD_License {
 
 		$this->maybe_set_pass_flag( $license, $license_data );
 
+		// Clear the option for licensed extensions to force regeneration.
+		if ( ! empty( $api_data->license ) && 'valid' === $api_data->license ) {
+			delete_option( 'edd_licensed_products' );
+		}
+
 		update_option( $this->item_shortname . '_license_active', $license_data );
 
 	}

--- a/includes/licensing/licensing-functions.php
+++ b/includes/licensing/licensing-functions.php
@@ -27,7 +27,7 @@ add_action( 'admin_init', function () {
 		return;
 	}
 
-	$savedOption = get_option( 'edd_licensed_products', array() );
+	$saved_products = get_option( 'edd_licensed_products', array() );
 
 	/*
 	 * We only want to update this option once per day. If the timeout has expired
@@ -37,7 +37,7 @@ add_action( 'admin_init', function () {
 	 * This is to help designate that the information has been checked and saved,
 	 * even if there are no licensed products.
 	 */
-	if ( empty( $savedOption['timeout'] ) || $savedOption['timeout'] < time() ) {
+	if ( empty( $saved_products['timeout'] ) || $saved_products['timeout'] < time() ) {
 		global $edd_licensed_products;
 
 		update_option( 'edd_licensed_products', json_encode( array(

--- a/includes/licensing/licensing-functions.php
+++ b/includes/licensing/licensing-functions.php
@@ -48,7 +48,7 @@ add_action( 'admin_init', function () {
 }, 200 );
 
 /**
- * Returns licensed EDD products that are active on this site.
+ * Returns licensed EDD extensions that are active on this site.
  * Array values are the `$item_shortname` from `\EDD_License`
  *
  * @see \EDD_License::$item_shortname
@@ -56,7 +56,7 @@ add_action( 'admin_init', function () {
  * @since 2.11.4
  * @return array
  */
-function get_licensed_products() {
+function get_licensed_extension_slugs() {
 	$products = get_option( 'edd_licensed_products' );
 
 	/*

--- a/includes/licensing/licensing-functions.php
+++ b/includes/licensing/licensing-functions.php
@@ -27,7 +27,7 @@ add_action( 'admin_init', function () {
 		return;
 	}
 
-	$saved_products = get_option( 'edd_licensed_products', array() );
+	$saved_products = get_option( 'edd_licensed_extensions', array() );
 
 	/*
 	 * We only want to update this option once per day. If the timeout has expired
@@ -40,7 +40,7 @@ add_action( 'admin_init', function () {
 	if ( empty( $saved_products['timeout'] ) || $saved_products['timeout'] < time() ) {
 		global $edd_licensed_products;
 
-		update_option( 'edd_licensed_products', json_encode( array(
+		update_option( 'edd_licensed_extensions', json_encode( array(
 			'timeout'  => strtotime( '+1 day' ),
 			'products' => $edd_licensed_products,
 		) ) );
@@ -57,7 +57,7 @@ add_action( 'admin_init', function () {
  * @return array
  */
 function get_licensed_extension_slugs() {
-	$products = get_option( 'edd_licensed_products' );
+	$products = get_option( 'edd_licensed_extensions' );
 
 	/*
 	 * If this isn't set for some reason, fall back to trying the global. There are


### PR DESCRIPTION
Fixes #8969 

Proposed Changes:
1. Hooks into `admin_init` and saves the content of the `$edd_licensed_products` global. This allows us to reliably access that data outside the context of `WP-Admin`.
    - Option is cached for 1 day to avoid excessive writing to the DB. So we only update it once per day.
2. Introduces a new helper function called `get_licensed_products()`. This is a wrapper for returning the result of that option.

I encountered this problem while testing https://github.com/awesomemotive/easy-digital-downloads/pull/8941 . Testing this fix requires working with that PR a bit.

## Testing

### Reproduce the problem

Create a new file in `wp-content/uploads` called `edd-notifications.json`. Paste in these contents:

```json
[
  {
    "title": "📣 New Multi-Currency Extension!",
    "content": "Now it's easy to add multiple currencies to your website!\r\n<br /><br />\r\nBlah blah blah.",
    "type": [
      "3-x"
    ],
    "id": 96,
    "btns": {
      "main": {
        "url": "https://easydigitaldownloads.com/downloads/multi-currency",
        "text": "Learn More"
      }
    },
    "notification_type": "success"
  },
  {
    "title": "📣 It's Time to Upgrade to 3.0!",
    "content": "Easy Digital Downloads 3.0 is here!\r\n<br /><br />\r\nUpgrade now for enhanced performance.",
    "type": [
      "2-x"
    ],
    "id": 92,
    "btns": {
      "main": {
        "url": "https://easydigitaldownloads.com/some-3-0-blog-post",
        "text": "Learn More"
      }
    },
    "notification_type": "success"
  },
  {
    "title": "📣 Upgrade to a Pass for More Features",
    "content": "You're using the free version of Easy Digital Downloads and it's time to upgrade!\r\n<br /><br />\r\nWe have passes available that add all kinds of extra features.",
    "type": [
      "free"
    ],
    "id": 94,
    "btns": {
      "main": {
        "url": "https://easydigitaldownloads.com/pricing",
        "text": "Upgrade"
      }
    },
    "notification_type": "success"
  },
  {
    "title": "📢 This Was Made in July!",
    "content": "This notification should not be imported because it was made in July.\r\n<br /><br />\r\nIf you can see it, there's something wrong.",
    "type": [],
    "id": 88,
    "start": "2021-07-28 11:36:58",
    "notification_type": "success"
  },
  {
    "title": "📢 This Notification Ended in October",
    "content": "This was a special notification for an October sale. Because it has ended, it should not be imported.",
    "type": [],
    "id": 86,
    "btns": {
      "main": {
        "url": "https://easydigitaldownloads.com/learn-more",
        "text": "Learn More"
      },
      "alt": {
        "url": "https://easydigitaldownloads.com/pricing/",
        "text": "Upgrade Now"
      }
    },
    "end": "2021-10-31 11:36:58",
    "notification_type": "success"
  }
]
```

Checkout `try/inbox` and pull up latest changes.

Drop your `wp_edd_notifications` table an corresponding `wp_options` entry.

Add this to your `wp-config.php` file:

```php
define( 'EDD_NOTIFICATIONS_API_URL', 'https://yoursite.com/wp-content/uploads/edd-notifications.json' );
```

Replace `yoursite.com` with your installation's domain name.

Go to Downloads > Settings > Licenses and enter a license key for Software Licensing. **Do not enter a pass license. It should be a license for Software Licensing only.**

Use a plugin like `WP Crontrol` or similar to manually trigger the `edd_daily_scheduled_events` event.

Visit any EDD page and you'll see 1 notification available:

![Screenshot from 2021-11-02 10-57-31](https://user-images.githubusercontent.com/6324272/139834198-f4d1d7a1-7e0e-42cf-8518-3a94a4f8272e.png)

Click on that icon to open the notifications panel. You'll see there are actually **two** notifications:

![Screenshot from 2021-11-02 10-58-00](https://user-images.githubusercontent.com/6324272/139834268-b85c805b-7003-47c0-a6ca-fa6cf59c6204.png)

You should not be getting that top one, because it should only be displaying for users with no license keys entered.

### Confirming the fix

- Make sure you're on `try/inbox`.
- Create a new branch just for testing. I created `try/inbox-fix`.
- Merge in this PR (`git merge issue/8969`)
- Open the notification panel.
- The incorrectly displayed notification should now **not** be shown.