### PR TITLE
Update edd_get_activation_date to optionally set date to first order

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1067,7 +1067,7 @@ function edd_get_activation_date( $use_first_order = false ) {
 			// Gets the first order placed in the store (any status).
 			$payments = edd_get_payments(
 				array(
-					'output'  => 'payments',
+					'output'  => 'posts',
 					'number'  => 1,
 					'orderby' => 'ID',
 					'order'   => 'ASC',
@@ -1075,9 +1075,9 @@ function edd_get_activation_date( $use_first_order = false ) {
 			);
 			if ( $payments ) {
 				$first_payment = reset( $payments );
-				// Use just the payment date, rather than completed date (first payment may not be complete).
-				if ( ! empty( $first_payment->date ) ) {
-					$activation_date = strtotime( $first_payment->date );
+				// Use just the post date, rather than looking for the completed date (first payment may not be complete).
+				if ( ! empty( $first_payment->post_date_gmt ) ) {
+					$activation_date = strtotime( $first_payment->post_date_gmt );
 				}
 			}
 		}

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1067,10 +1067,11 @@ function edd_get_activation_date( $use_first_order = false ) {
 			// Gets the first order placed in the store (any status).
 			$payments = edd_get_payments(
 				array(
-					'output'  => 'posts',
-					'number'  => 1,
-					'orderby' => 'ID',
-					'order'   => 'ASC',
+					'output'        => 'posts',
+					'number'        => 1,
+					'orderby'       => 'ID',
+					'order'         => 'ASC',
+					'no_found_rows' => true,
 				)
 			);
 			if ( $payments ) {

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1056,30 +1056,27 @@ function edd_is_promo_active() {
  * For existing installs, this option is added whenever the function is first used.
  *
  * @since 2.11.4
- * @param bool $use_first_order Optional flag to use the first existing order date.
- * @return int The timestamp when EDD was activated.
+ * @return int The timestamp when EDD was marked as activated.
  */
-function edd_get_activation_date( $use_first_order = false ) {
+function edd_get_activation_date() {
 	$activation_date = get_option( 'edd_activation_date', '' );
 	if ( ! $activation_date ) {
 		$activation_date = time();
-		if ( $use_first_order ) {
-			// Gets the first order placed in the store (any status).
-			$payments = edd_get_payments(
-				array(
-					'output'        => 'posts',
-					'number'        => 1,
-					'orderby'       => 'ID',
-					'order'         => 'ASC',
-					'no_found_rows' => true,
-				)
-			);
-			if ( $payments ) {
-				$first_payment = reset( $payments );
-				// Use just the post date, rather than looking for the completed date (first payment may not be complete).
-				if ( ! empty( $first_payment->post_date_gmt ) ) {
-					$activation_date = strtotime( $first_payment->post_date_gmt );
-				}
+		// Gets the first order placed in the store (any status).
+		$payments = edd_get_payments(
+			array(
+				'output'        => 'posts',
+				'number'        => 1,
+				'orderby'       => 'ID',
+				'order'         => 'ASC',
+				'no_found_rows' => true,
+			)
+		);
+		if ( $payments ) {
+			$first_payment = reset( $payments );
+			// Use just the post date, rather than looking for the completed date (first payment may not be complete).
+			if ( ! empty( $first_payment->post_date_gmt ) ) {
+				$activation_date = strtotime( $first_payment->post_date_gmt );
 			}
 		}
 		update_option( 'edd_activation_date', $activation_date );

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1056,12 +1056,31 @@ function edd_is_promo_active() {
  * For existing installs, this option is added whenever the function is first used.
  *
  * @since 2.11.4
+ * @param bool $use_first_order Optional flag to use the first existing order date.
  * @return int The timestamp when EDD was activated.
  */
-function edd_get_activation_date() {
+function edd_get_activation_date( $use_first_order = false ) {
 	$activation_date = get_option( 'edd_activation_date', '' );
 	if ( ! $activation_date ) {
 		$activation_date = time();
+		if ( $use_first_order ) {
+			// Gets the first order placed in the store (any status).
+			$payments = edd_get_payments(
+				array(
+					'output'  => 'payments',
+					'number'  => 1,
+					'orderby' => 'ID',
+					'order'   => 'ASC',
+				)
+			);
+			if ( $payments ) {
+				$first_payment = reset( $payments );
+				// Use just the payment date, rather than completed date (first payment may not be complete).
+				if ( ! empty( $first_payment->date ) ) {
+					$activation_date = strtotime( $first_payment->date );
+				}
+			}
+		}
 		update_option( 'edd_activation_date', $activation_date );
 	}
 


### PR DESCRIPTION
Fixes #8975

Proposed Changes:
1. Adds an optional boolean parameter `$use_first_order` to the `edd_get_activation_date` function. Set to false by default.
2. If called outside of the initial installation, set the parameter to `true` to run a quick payments query to get the first order from the database.
3. If an order is retrieved, use its date as the activation date (this is not necessarily a complete order so I'm just using the date, not completed date).
4. So when we run the installer, we would not pass a parameter, but using it elsewhere, which might happen for an existing install, we would.

On my own storefront, this changes the activation date from today (`1636029820`) to `1434612134`, which is June 2015.
