### PR TITLE
Performance Improvement in batch export earnings report

### DIFF
--- a/includes/admin/reporting/export/class-batch-export-earnings-report.php
+++ b/includes/admin/reporting/export/class-batch-export-earnings-report.php
@@ -119,10 +119,10 @@ class EDD_Batch_Earnings_Report_Export extends EDD_Batch_Export {
 	 * @return array $cols CSV header.
 	 */
 	public function print_csv_cols() {
-		$cols     = $this->get_csv_cols();
-		$col_data = '';
-		$count    = count( $cols );
-		for ( $i = 0; $i < $count; $i++ ) {
+		$cols         = $this->get_csv_cols();
+		$col_data     = '';
+		$column_count = count( $cols );
+		for ( $i = 0; $i < $column_count; $i++ ) {
 			$col_data .= $cols[ $i ];
 
 			// We don't need an extra space after the first column
@@ -131,7 +131,7 @@ class EDD_Batch_Earnings_Report_Export extends EDD_Batch_Export {
 				continue;
 			}
 
-			if ( $i == ( $count - 1 ) ) {
+			if ( $i == ( $column_count - 1 ) ) {
 				$col_data .= "\r\n";
 			} else {
 				$col_data .= ",,";

--- a/includes/admin/reporting/export/class-batch-export-earnings-report.php
+++ b/includes/admin/reporting/export/class-batch-export-earnings-report.php
@@ -121,8 +121,8 @@ class EDD_Batch_Earnings_Report_Export extends EDD_Batch_Export {
 	public function print_csv_cols() {
 		$cols     = $this->get_csv_cols();
 		$col_data = '';
-
-		for ( $i = 0; $i < count( $cols ); $i++ ) {
+		$count    = count( $cols );
+		for ( $i = 0; $i < $count; $i++ ) {
 			$col_data .= $cols[ $i ];
 
 			// We don't need an extra space after the first column
@@ -131,7 +131,7 @@ class EDD_Batch_Earnings_Report_Export extends EDD_Batch_Export {
 				continue;
 			}
 
-			if ( $i == ( count( $cols ) - 1 ) ) {
+			if ( $i == ( $count - 1 ) ) {
 				$col_data .= "\r\n";
 			} else {
 				$col_data .= ",,";


### PR DESCRIPTION
The counting of cols is done twice per iteration even though the number of colls is not being manipulated in the loop. Pre-computing the number ahead of the loop will same 2n performance of the operation (O(n) savings of performance).

Fixes #: (none)

Using PR to test a SAST. 

Proposed Changes:
1. Pre-compute count of $cols as $count ahead of loop
2. Replace count( $cols) with $count inside loop