### PR TITLE
Add unlisted property

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -130,6 +130,14 @@ final class Easy_Digital_Downloads {
 	public $cart;
 
 	/**
+	 * EDD Payment Stats Object
+	 *
+	 * @var object|EDD_Payment_Stats
+	 * @since 1.8
+	 */
+	public $payment_stats;
+
+	/**
 	 * Main Easy_Digital_Downloads Instance.
 	 *
 	 * Insures that only one instance of Easy_Digital_Downloads exists in memory at any one

--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -132,7 +132,7 @@ final class Easy_Digital_Downloads {
 	/**
 	 * EDD Payment Stats Object
 	 *
-	 * @var object|EDD_Payment_Stats
+	 * @var EDD_Payment_Stats
 	 * @since 1.8
 	 */
 	public $payment_stats;


### PR DESCRIPTION
In PHP it is possible to write to properties without declaring them. For example, the following is perfectly valid PHP code:
```
class MyClass { }

$x = new MyClass();
$x->foo = true;
```

Generally, it is a good practice to explictly declare properties to avoid accidental typos and provide IDE auto-completion:
```
class MyClass {
    public $foo;
}

$x = new MyClass();
$x->foo = true;
```

Fixes # (none)

Proposed Changes:
1. Add unlisted payment_stats property
