### PR TITLE
Use highest pass license key for updating if a specific key is not set

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -332,13 +332,13 @@ final class Easy_Digital_Downloads {
 		require_once EDD_PLUGIN_DIR . 'includes/admin/tracking.php'; // Must be loaded on frontend to ensure cron runs
 		require_once EDD_PLUGIN_DIR . 'includes/privacy-functions.php';
 		require_once EDD_PLUGIN_DIR . 'includes/utils/class-tokenizer.php';
+		require_once EDD_PLUGIN_DIR . 'includes/admin/class-pass-manager.php'; // Must be loaded on front end for cron
 
 		if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 			require_once EDD_PLUGIN_DIR . 'includes/admin/add-ons.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/admin-footer.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/admin-actions.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/class-edd-notices.php';
-			require_once EDD_PLUGIN_DIR . 'includes/admin/class-pass-manager.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/admin-pages.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/dashboard-widgets.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/thickbox.php';

--- a/includes/class-edd-license-handler.php
+++ b/includes/class-edd-license-handler.php
@@ -160,9 +160,8 @@ class EDD_License {
 		// Fall back to the highest license key if one is not saved for this extension.
 		if ( empty( $license ) ) {
 			$pass_manager = new \EDD\Admin\Pass_Manager();
-			$highest_key  = $pass_manager->highest_license_key;
-			if ( $highest_key ) {
-				$license = $highest_key;
+			if ( $pass_manager->highest_license_key ) {
+				$license = $pass_manager->highest_license_key;
 			}
 		}
 		$betas = edd_get_option( 'enabled_betas', array() );

--- a/includes/class-edd-license-handler.php
+++ b/includes/class-edd-license-handler.php
@@ -156,11 +156,20 @@ class EDD_License {
 			return;
 		}
 
+		$license = $this->license;
+		// Fall back to the highest license key if one is not saved for this extension.
+		if ( empty( $license ) ) {
+			$pass_manager = new \EDD\Admin\Pass_Manager();
+			$highest_key  = $pass_manager->highest_license_key;
+			if ( $highest_key ) {
+				$license = $highest_key;
+			}
+		}
 		$betas = edd_get_option( 'enabled_betas', array() );
 
 		$args = array(
 			'version'   => $this->version,
-			'license'   => $this->license,
+			'license'   => $license,
 			'author'    => $this->author,
 			'beta'      => function_exists( 'edd_extension_has_beta_support' ) && edd_extension_has_beta_support( $this->item_shortname ),
 		);

--- a/tests/tests-pass-manager.php
+++ b/tests/tests-pass-manager.php
@@ -78,7 +78,7 @@ class Pass_Manager extends \EDD_UnitTestCase {
 	/**
 	 * If you have both a Personal and Professional pass activated, the Professional should be highest.
 	 *
-	 * @covers \EDD\Admin\Pass_Manager::get_highest_pass_id
+	 * @covers \EDD\Admin\Pass_Manager::set_highest_pass_data()
 	 */
 	public function test_professional_is_highest_pass() {
 		$passes = array(
@@ -102,7 +102,7 @@ class Pass_Manager extends \EDD_UnitTestCase {
 	 * If you have a pass entered, but it was last verified more than 2 months ago (1 year ago
 	 * in this case), then it should not be accepted as a valid pass.
 	 *
-	 * @covers \EDD\Admin\Pass_Manager::get_highest_pass_id
+	 * @covers \EDD\Admin\Pass_Manager::set_highest_pass_data()
 	 */
 	public function test_no_pass_id_if_pass_outside_check_window() {
 		$passes = array(


### PR DESCRIPTION
Fixes #8980

Proposed Changes:
1. Adds a highest license key property to the `Pass_Manager` class.
2. Instead of just getting the highest pass ID, set the highest pass ID and license key together when evaluating passes.
3. Update related tests docs.
4. When setting up the auto update class in `EDD_License`, if no license key is saved for the extension, but a pass license key is available, use that for the auto updater.

Note that the Pass Manager class changes are pulled directly from #8945. Additionally, I have branched this off of 2.11.4 although the issue is not currently milestoned.