### PR TITLE
Add failure notice if purchase receipt could not be re-sent

### DIFF
--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -222,7 +222,7 @@ class EDD_Notices {
 						$notices['updated']['edd-payment-sent'] = __( 'The purchase receipt has been resent.', 'easy-digital-downloads' );
 						break;
 					case 'email_send_failed':
-						$notices['error']['edd-payment-sent'] = __( 'The purchase receipt was not successfully sent.', 'easy-digital-downloads' );
+						$notices['error']['edd-payment-sent'] = __( 'Failed to send purchase receipt.', 'easy-digital-downloads' );
 						break;
 					case 'refreshed-reports' :
 						$notices['updated']['edd-refreshed-reports'] = __( 'The reports have been refreshed.', 'easy-digital-downloads' );

--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -221,6 +221,9 @@ class EDD_Notices {
 					case 'email_sent' :
 						$notices['updated']['edd-payment-sent'] = __( 'The purchase receipt has been resent.', 'easy-digital-downloads' );
 						break;
+					case 'email_send_failed':
+						$notices['error']['edd-payment-sent'] = __( 'The purchase receipt was not successfully sent.', 'easy-digital-downloads' );
+						break;
 					case 'refreshed-reports' :
 						$notices['updated']['edd-refreshed-reports'] = __( 'The reports have been refreshed.', 'easy-digital-downloads' );
 						break;

--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -60,7 +60,7 @@ function edd_resend_purchase_receipt( $data ) {
 		$email    = $customer->email;
 	}
 
-	edd_email_purchase_receipt( $purchase_id, false, $email );
+	$sent = edd_email_purchase_receipt( $purchase_id, false, $email );
 
 	// Grab all downloads of the purchase and update their file download limits, if needed
 	// This allows admins to resend purchase receipts to grant additional file downloads
@@ -75,7 +75,15 @@ function edd_resend_purchase_receipt( $data ) {
 		}
 	}
 
-	wp_redirect( add_query_arg( array( 'edd-message' => 'email_sent', 'edd-action' => false, 'purchase_id' => false ) ) );
+	wp_safe_redirect(
+		add_query_arg(
+			array(
+				'edd-message' => $sent ? 'email_sent' : 'email_send_failed',
+				'edd-action'  => false,
+				'purchase_id' => false,
+			)
+		)
+	);
 	exit;
 }
 add_action( 'edd_email_links', 'edd_resend_purchase_receipt' );

--- a/includes/emails/class-edd-emails.php
+++ b/includes/emails/class-edd-emails.php
@@ -283,6 +283,8 @@ class EDD_Emails {
 	 * @param  string  $subject          The subject line of the email to send.
 	 * @param  string  $message          The body of the email to send.
 	 * @param  string|array $attachments Attachments to the email in a format supported by wp_mail()
+	 *
+	 * @return bool Whether the email was sent successfully.
 	 * @since 2.1
 	 */
 	public function send( $to, $subject, $message, $attachments = '' ) {

--- a/includes/emails/functions.php
+++ b/includes/emails/functions.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * @param bool         $admin_notice Whether to send the admin email notification or not (default: true)
  * @param EDD_Payment  $payment      Payment object for payment ID.
  * @param EDD_Customer $customer     Customer object for associated payment.
- * @return void
+ * @return bool Whether the email was sent successfully.
  */
 function edd_email_purchase_receipt( $payment_id, $admin_notice = true, $to_email = '', $payment = null, $customer = null ) {
 	if ( is_null( $payment ) ) {
@@ -63,11 +63,13 @@ function edd_email_purchase_receipt( $payment_id, $admin_notice = true, $to_emai
 	$headers = apply_filters( 'edd_receipt_headers', $emails->get_headers(), $payment_id, $payment_data );
 	$emails->__set( 'headers', $headers );
 
-	$emails->send( $to_email, $subject, $message, $attachments );
+	$sent = $emails->send( $to_email, $subject, $message, $attachments );
 
 	if ( $admin_notice && ! edd_admin_notices_disabled( $payment_id ) ) {
 		do_action( 'edd_admin_sale_notice', $payment_id, $payment_data );
 	}
+
+	return $sent;
 }
 
 /**


### PR DESCRIPTION
Fixes #8986

Proposed Changes:
1. Updates the emails `send` method to document the `return`.
2. Updates `edd_email_purchase_receipt` to use that boolean and also return it.
3. If that returns `false` when resending the purchase receipt, generate a failure/error notice.