### PR TITLE
Simplify start & end logic to always use last day of month #8995

### DIFF
--- a/includes/admin/reporting/export/class-batch-export-earnings-report.php
+++ b/includes/admin/reporting/export/class-batch-export-earnings-report.php
@@ -249,21 +249,12 @@ class EDD_Batch_Earnings_Report_Export extends EDD_Batch_Export {
 		$data = array();
 
 		$start_date = date( 'Y-m-d 00:00:00', strtotime( $this->start ) );
-
-		if ( $this->count() == 0 ) {
-			$end_date = date( 'Y-m-d 23:59:59', strtotime( $this->end ) );
-		} else {
-			$end_date = date( 'Y-m-d 23:59:59', strtotime( 'first day of +1 month', strtotime( $start_date ) ) );
-		}
+		$end_date   = date( 'Y-m-t 23:59:59', strtotime( $this->start ) );
 
 		if ( $this->step > 1 ) {
-			$start_date = date( 'Y-m-d 00:00:00', strtotime( 'first day of +' . ( $this->step - 1 ) . ' month', strtotime( $start_date ) ) );
-
-			if ( date( 'Y-m', strtotime( $start_date ) ) == date( 'Y-m', strtotime( $this->end ) ) ) {
-				$end_date = date( 'Y-m-d 23:59:59', strtotime( $this->end ) );
-			} else {
-				$end_date = date( 'Y-m-d 23:59:59', strtotime( 'first day of +1 month', strtotime( $start_date ) ) );
-			}
+			$start_timestamp = strtotime( 'first day of +' . ( $this->step - 1 ) . ' month', strtotime( $start_date ) );
+			$start_date      = date( 'Y-m-d 00:00:00', $start_timestamp );
+			$end_date        = date( 'Y-m-t 23:59:59', $start_timestamp );
 		}
 
 		if ( strtotime( $start_date ) > strtotime( $this->end ) ) {
@@ -278,7 +269,7 @@ class EDD_Batch_Earnings_Report_Export extends EDD_Batch_Export {
 			 WHERE posts.post_type IN ('edd_payment')
 			 AND {$wpdb->postmeta}.meta_key = '_edd_payment_total'
 			 AND posts.post_date >= %s
-			 AND posts.post_date < %s
+			 AND posts.post_date <= %s
 			 GROUP BY YEAR(posts.post_date), MONTH(posts.post_date), posts.post_status
 			 ORDER by posts.post_date ASC", $start_date, $end_date ), ARRAY_A );
 


### PR DESCRIPTION
Fixes #8995

Proposed Changes:
Simplify the start and end date logic. The end date is now always set to the last day of the start date's month (using the `t` date format). So instead of this:

```mysql
  AND posts.post_date >= '2021-08-01 00:00:00'
  AND posts.post_date < '2021-09-01 23:59:59'
```

we should be seeing this:

```mysql
  AND posts.post_date >= '2021-08-01 00:00:00'
  AND posts.post_date <= '2021-08-31 23:59:59'
```

This ensure we only ever work within 1 month.

To account for this, you'll note I also changed the query comparison to `<=` instead of `<`.

To test, I honestly just found it easiest to log this query: https://github.com/awesomemotive/easy-digital-downloads/blob/b48c077c245b1329e0244aa30d5ff3728bedce4c/includes/admin/reporting/export/class-batch-export-earnings-report.php#L265-L274 while running a few exports. Ensure the date ranges make sense.