### PR TITLE
Add webp to supported file, image types

### DIFF
--- a/includes/admin/upload-functions.php
+++ b/includes/admin/upload-functions.php
@@ -150,7 +150,7 @@ function edd_get_htaccess_rules( $method = false ) {
 		case 'direct' :
 		default :
 			// Prevent directory browsing and direct access to all files, except images (they must be allowed for featured images / thumbnails)
-			$allowed_filetypes = apply_filters( 'edd_protected_directory_allowed_filetypes', array( 'jpg', 'jpeg', 'png', 'gif', 'mp3', 'ogg' ) );
+			$allowed_filetypes = apply_filters( 'edd_protected_directory_allowed_filetypes', array( 'jpg', 'jpeg', 'png', 'gif', 'mp3', 'ogg', 'webp' ) );
 			$rules = "Options -Indexes\n";
 			$rules .= "deny from all\n";
 			$rules .= "<FilesMatch '\.(" . implode( '|', $allowed_filetypes ) . ")$'>\n";

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -148,21 +148,18 @@ function edd_string_is_image_url( $str ) {
 	$ext = edd_get_file_extension( $str );
 
 	switch ( strtolower( $ext ) ) {
-		case 'jpg';
-			$return = true;
-			break;
-		case 'png';
-			$return = true;
-			break;
-		case 'gif';
-			$return = true;
+		case 'jpg':
+		case 'png':
+		case 'gif':
+		case 'webp':
+			$is_image = true;
 			break;
 		default:
-			$return = false;
+			$is_image = false;
 			break;
 	}
 
-	return (bool) apply_filters( 'edd_string_is_image', $return, $str );
+	return (bool) apply_filters( 'edd_string_is_image', $is_image, $str );
 }
 
 /**

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -141,25 +141,14 @@ function edd_get_file_extension( $str ) {
  * Checks if the string (filename) provided is an image URL
  *
  * @since 1.0
- * @param string  $str Filename
+ * @param string  $filename Filename
  * @return bool Whether or not the filename is an image
  */
-function edd_string_is_image_url( $str ) {
-	$ext = edd_get_file_extension( $str );
+function edd_string_is_image_url( $filename ) {
+	$ext    = edd_get_file_extension( $filename );
+	$images = array( 'jpg', 'jpeg', 'png', 'gif', 'webp' );
 
-	switch ( strtolower( $ext ) ) {
-		case 'jpg':
-		case 'png':
-		case 'gif':
-		case 'webp':
-			$is_image = true;
-			break;
-		default:
-			$is_image = false;
-			break;
-	}
-
-	return (bool) apply_filters( 'edd_string_is_image', $is_image, $str );
+	return (bool) apply_filters( 'edd_string_is_image', in_array( $ext, $images, true ), $filename );
 }
 
 /**

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -699,6 +699,7 @@ function edd_get_file_ctype( $extension ) {
 		case 'wav'      : $ctype = "audio/x-wav"; break;
 		case 'wbmp'     : $ctype = "image/vnd.wap.wbmp"; break;
 		case 'wbmxl'    : $ctype = "application/vnd.wap.wbxml"; break;
+		case 'webp'     : $ctype = "image/webp"; break;
 		case 'wm'       : $ctype = "video/x-ms-wm"; break;
 		case 'wml'      : $ctype = "text/vnd.wap.wml"; break;
 		case 'wmlc'     : $ctype = "application/vnd.wap.wmlc"; break;

--- a/tests/tests-misc.php
+++ b/tests/tests-misc.php
@@ -45,6 +45,7 @@ class Test_Misc extends EDD_UnitTestCase {
 
 	public function test_string_is_image_url() {
 		$this->assertTrue( edd_string_is_image_url( 'jpg' ) );
+		$this->assertTrue( edd_string_is_image_url( 'webp' ) );
 		$this->assertFalse( edd_string_is_image_url( 'php' ) );
 	}
 


### PR DESCRIPTION
Fixes #8999

Proposed Changes:
1. Adds `webp` to `edd_protected_directory_allowed_filetypes`.
2. Updates `edd_string_is_image_url` to include `webp` and condense logic.
3. Adds `webp` to `edd_get_file_ctype`.
4. Adds `webp` assertion to `test_string_is_image_url`.