### PR TITLE
Refactor edd_get_settings_tabs

### DIFF
--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -55,10 +55,9 @@ function edd_options_page() {
 	$all_settings = edd_get_registered_settings();
 
 	// Remove tabs that don't have settings fields.
-	$tabs_with_settings = array_keys( $all_settings );
-	foreach ( $tabs_with_settings as $tab_with_settings ) {
-		if ( empty( $all_settings[ $tab_with_settings ] ) ) {
-			unset( $settings_tabs[ $tab_with_settings ] );
+	foreach ( array_keys( $settings_tabs ) as $settings_tab ) {
+		if ( empty( $all_settings[ $settings_tab ] ) ) {
+			unset( $settings_tabs[ $settings_tab ] );
 		}
 	}
 

--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -50,11 +50,17 @@ function edd_options_page() {
 		$key = key( $sections );
 	}
 
-	$registered_sections = edd_get_settings_tab_sections( $active_tab );
-	$section             = isset( $_GET['section'] ) && ! empty( $registered_sections ) && array_key_exists( $_GET['section'], $registered_sections ) ? sanitize_text_field( $_GET['section'] ) : $key;
+	$section = isset( $_GET['section'] ) && ! empty( $sections ) && array_key_exists( $_GET['section'], $sections ) ? sanitize_text_field( $_GET['section'] ) : $key;
 
-	// Unset 'main' if it's empty and default to the first non-empty if it's the chosen section
 	$all_settings = edd_get_registered_settings();
+
+	// Remove tabs that don't have settings fields.
+	$tabs_with_settings = array_keys( $all_settings );
+	foreach ( $tabs_with_settings as $tab_with_settings ) {
+		if ( empty( $all_settings[ $tab_with_settings ] ) ) {
+			unset( $settings_tabs[ $tab_with_settings ] );
+		}
+	}
 
 	// Let's verify we have a 'main' section to show
 	$has_main_settings = true;
@@ -75,6 +81,7 @@ function edd_options_page() {
 	}
 
 	$override = false;
+	// Unset 'main' if it's empty and default to the first non-empty if it's the chosen section
 	if ( false === $has_main_settings ) {
 		unset( $sections['main'] );
 
@@ -95,7 +102,7 @@ function edd_options_page() {
 		<h1><?php esc_html_e( 'Settings', 'easy-digital-downloads' ); ?></h1>
 		<h2 class="nav-tab-wrapper">
 			<?php
-			foreach ( edd_get_settings_tabs() as $tab_id => $tab_name ) {
+			foreach ( $settings_tabs as $tab_id => $tab_name ) {
 				$tab_url = add_query_arg( array(
 					'settings-updated' => false,
 					'tab'              => $tab_id,

--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -50,7 +50,7 @@ function edd_options_page() {
 		$key = key( $sections );
 	}
 
-	$section = isset( $_GET['section'] ) && ! empty( $sections ) && array_key_exists( $_GET['section'], $sections ) ? sanitize_text_field( $_GET['section'] ) : $key;
+	$section = ! empty( $_GET['section'] ) && ! empty( $sections[ $_GET['section'] ] ) ? sanitize_text_field( $_GET['section'] ) : $key;
 
 	$all_settings = edd_get_registered_settings();
 

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1360,6 +1360,7 @@ function edd_sanitize_html_class( $class = '' ) {
  * Retrieve settings tabs
  *
  * @since 1.8
+ * @since 2.11.4 Any tabs with no registered settings are filtered out in `edd_options_page`.
  * @return array $tabs
  */
 function edd_get_settings_tabs() {

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1364,26 +1364,17 @@ function edd_sanitize_html_class( $class = '' ) {
  */
 function edd_get_settings_tabs() {
 
-	$settings = edd_get_registered_settings();
-
-	$tabs             = array();
-	$tabs['general']  = __( 'General', 'easy-digital-downloads' );
-	$tabs['gateways'] = __( 'Payments', 'easy-digital-downloads' );
-	$tabs['emails']   = __( 'Emails', 'easy-digital-downloads' );
-	$tabs['styles']   = __( 'Styles', 'easy-digital-downloads' );
-	$tabs['taxes']    = __( 'Taxes', 'easy-digital-downloads' );
-	$tabs['privacy']  = __( 'Privacy', 'easy-digital-downloads' );
-
-	if( ! empty( $settings['extensions'] ) ) {
-		$tabs['extensions'] = __( 'Extensions', 'easy-digital-downloads' );
-	}
-	if( ! empty( $settings['licenses'] ) ) {
-		$tabs['licenses'] = __( 'Licenses', 'easy-digital-downloads' );
-	}
-
-	$tabs['misc']      = __( 'Misc', 'easy-digital-downloads' );
-
-	return apply_filters( 'edd_settings_tabs', $tabs );
+	return apply_filters( 'edd_settings_tabs', array(
+		'general'    => __( 'General', 'easy-digital-downloads' ),
+		'gateways'   => __( 'Payments', 'easy-digital-downloads' ),
+		'emails'     => __( 'Emails', 'easy-digital-downloads' ),
+		'styles'     => __( 'Styles', 'easy-digital-downloads' ),
+		'taxes'      => __( 'Taxes', 'easy-digital-downloads' ),
+		'privacy'    => __( 'Privacy', 'easy-digital-downloads' ),
+		'extensions' => __( 'Extensions', 'easy-digital-downloads' ),
+		'licenses'   => __( 'Licenses', 'easy-digital-downloads' ),
+		'misc'       => __( 'Misc', 'easy-digital-downloads' ),
+	) );
 }
 
 /**


### PR DESCRIPTION
Fixes #9001

Proposed Changes:
1. Do not get all of the registered settings within `edd_get_settings_tabs`.
2. Update `edd_options_page`:
    - Remove duplicate `edd_get_settings_tab_sections`.
    - Remove duplicate `edd_get_settings_tabs`.
    - Evaluate the settings tabs against the registered settings, which have already been pulled, and remove any tabs which have no settings.
