### PR TITLE
Add product tabs back to downloads screen

### DIFF
--- a/includes/admin/admin-actions.php
+++ b/includes/admin/admin-actions.php
@@ -35,6 +35,7 @@ add_action( 'admin_init', 'edd_process_actions' );
  *
  * @since 2.8.9
  * @since 2.11.3 Unhooked this to revert to standard admin H1 tags.
+ * @since 3.0    Added back as download categories/tags have been removed from the admin menu.
  * @param $views
  *
  * @return mixed

--- a/includes/admin/admin-actions.php
+++ b/includes/admin/admin-actions.php
@@ -44,7 +44,7 @@ function edd_products_tabs( $views ) {
 
 	return $views;
 }
-//add_filter( 'views_edit-download', 'edd_products_tabs', 10, 1 );
+add_filter( 'views_edit-download', 'edd_products_tabs', 10, 1 );
 
 /**
  * When the Download list table loads, call the function to view our tabs.


### PR DESCRIPTION
Fixes #9003

Proposed Changes:
1. Just comments out the `add_filter( 'views_edit-download' ...` line that was commented out for 2.11.3. There doesn't seem to be a more practical way to add this, and this will keep it consistent with the taxonomy screens.