### PR TITLE
Update active license options checks

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -2571,7 +2571,7 @@ if ( ! function_exists( 'edd_license_key_callback' ) ) {
 		$size = ( isset( $args['size'] ) && ! is_null( $args['size'] ) ) ? $args['size'] : 'regular';
 		$html = '<input type="password" autocomplete="off" class="' . sanitize_html_class( $size ) . '-text" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" value="' . esc_attr( $value ) . '"/>';
 
-		if ( ( is_object( $license ) && 'valid' == $license->license ) || 'valid' == $license ) {
+		if ( ( is_object( $license ) && ! empty( $license->license ) && 'valid' == $license->license ) || 'valid' == $license ) {
 			$html .= '<input type="submit" class="button-secondary" name="' . $args['id'] . '_deactivate" value="' . __( 'Deactivate License',  'easy-digital-downloads' ) . '"/>';
 		}
 

--- a/includes/class-edd-license-handler.php
+++ b/includes/class-edd-license-handler.php
@@ -325,7 +325,7 @@ class EDD_License {
 
 		$details = get_option( $this->item_shortname . '_license_active' );
 
-		if ( is_object( $details ) && 'valid' === $details->license ) {
+		if ( is_object( $details ) && ! empty( $details->license ) && 'valid' === $details->license ) {
 			return;
 		}
 
@@ -517,7 +517,7 @@ class EDD_License {
 
 		$license = get_option( $this->item_shortname . '_license_active' );
 
-		if( is_object( $license ) && 'valid' !== $license->license && empty( $showed_invalid_message ) ) {
+		if( is_object( $license ) && ( empty( $license->license ) || 'valid' !== $license->license ) && empty( $showed_invalid_message ) ) {
 
 			if( empty( $_GET['tab'] ) || 'licenses' !== $_GET['tab'] ) {
 
@@ -558,7 +558,7 @@ class EDD_License {
 
 		$license = get_option( $this->item_shortname . '_license_active' );
 
-		if( ( ! is_object( $license ) || 'valid' !== $license->license ) && empty( $showed_imissing_key_message[ $this->item_shortname ] ) ) {
+		if ( ( ! is_object( $license ) || empty( $license->license ) || 'valid' !== $license->license ) && empty( $showed_imissing_key_message[ $this->item_shortname ] ) ) {
 
 			echo '&nbsp;<strong><a href="' . esc_url( admin_url( 'edit.php?post_type=download&page=edd-settings&tab=licenses' ) ) . '">' . __( 'Enter valid license key for automatic updates.', 'easy-digital-downloads' ) . '</a></strong>';
 			$showed_imissing_key_message[ $this->item_shortname ] = true;


### PR DESCRIPTION
Fixes #9010

Proposed Changes:
1. When checking the `*_license_active` option, check if the `license` property is set before checking whether it is `'valid'`. This is in a few different places:
    - When evaluating whether to show the "Deactivate" button for an active license.
    - When evaluating whether to show a warning notice with the license key input.
    - When evaluating whether to show a general admin notice.
    - If a plugin is out of date, a message is added to the plugin row update notice as well.