### PR TITLE
Do not send purchase email when creating a refund

### DIFF
--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -28,6 +28,9 @@ function edd_trigger_purchase_receipt( $payment_id = 0, $payment = null, $custom
 	if ( isset( $_POST['edd-action'] ) && 'edit_payment' == $_POST['edd-action'] ) {
 		return;
 	}
+	if ( null === $payment ) {
+		$payment = new EDD_Payment( $payment_id );
+	}
 	if ( 'refund' === $payment->order->type ) {
 		return;
 	}

--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -31,7 +31,7 @@ function edd_trigger_purchase_receipt( $payment_id = 0, $payment = null, $custom
 	if ( null === $payment ) {
 		$payment = new EDD_Payment( $payment_id );
 	}
-	if ( 'refund' === $payment->order->type ) {
+	if ( $payment->order instanceof \EDD\Orders\Order && 'refund' === $payment->order->type ) {
 		return;
 	}
 

--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -28,6 +28,9 @@ function edd_trigger_purchase_receipt( $payment_id = 0, $payment = null, $custom
 	if ( isset( $_POST['edd-action'] ) && 'edit_payment' == $_POST['edd-action'] ) {
 		return;
 	}
+	if ( 'refund' === $payment->order->type ) {
+		return;
+	}
 
 	// Send email with secure download link
 	edd_email_purchase_receipt( $payment_id, true, '', $payment, $customer );


### PR DESCRIPTION
Fixes #9025 

Proposed Changes:
1. Updates `edd_trigger_purchase_receipt` to check for the order type and returns early if it's a `refund`.