### PR TITLE
Update batch importer to use str_getcsv instead of an external library

### DIFF
--- a/includes/admin/import/class-batch-import-downloads.php
+++ b/includes/admin/import/class-batch-import-downloads.php
@@ -75,11 +75,11 @@ class EDD_Batch_Downloads_Import extends EDD_Batch_Import {
 			unlink( $this->file );
 		}
 
-		if( ! $this->done && $this->csv->data ) {
+		if( ! $this->done && $this->csv ) {
 
 			$more = true;
 
-			foreach( $this->csv->data as $key => $row ) {
+			foreach( $this->csv as $key => $row ) {
 
 				// Skip all rows until we pass our offset
 				if( $key + 1 <= $offset ) {

--- a/includes/admin/import/class-batch-import-payments.php
+++ b/includes/admin/import/class-batch-import-payments.php
@@ -546,7 +546,10 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 
 			foreach( $downloads as $key => $download ) {
 
-				$d   = (array) explode( '|', $download );
+				$d = (array) explode( '|', $download );
+				if ( ! array_key_exists( 1, $d ) ) {
+					continue;
+				}
 				preg_match_all( '/\{(\d|(\d+(\.\d+|\d+)))\}/', $d[1], $matches );
 
 				if( false !== strpos( $d[1], '{' ) ) {

--- a/includes/admin/import/class-batch-import-payments.php
+++ b/includes/admin/import/class-batch-import-payments.php
@@ -393,6 +393,9 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 
 		global $wpdb;
 
+		$customer = false;
+		$email    = '';
+
 		if( ! empty( $this->field_mapping['email'] ) && ! empty( $row[ $this->field_mapping['email'] ] ) ) {
 
 			$email = sanitize_text_field( $row[ $this->field_mapping['email'] ] );
@@ -435,7 +438,7 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 
 			// Now compare customer records. If they don't match, customer_id will be stored in meta and we will use the customer that matches the email
 
-			if( ( empty( $customer_by_id ) || $customer_by_id->id !== $customer_by_email->id ) && ! empty( $customer_by_email ) )  {
+			if ( ! empty( $customer_by_email ) && ( empty( $customer_by_id ) || $customer_by_id->id !== $customer_by_email->id ) )  {
 
 				$customer = $customer_by_email;
 

--- a/includes/admin/import/class-batch-import-payments.php
+++ b/includes/admin/import/class-batch-import-payments.php
@@ -95,11 +95,11 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 			unlink( $this->file );
 		}
 
-		if( ! $this->done && $this->csv->data ) {
+		if( ! $this->done && $this->csv ) {
 
 			$more = true;
 
-			foreach( $this->csv->data as $key => $row ) {
+			foreach( $this->csv as $key => $row ) {
 
 				// Skip all rows until we pass our offset
 				if( $key + 1 <= $offset ) {
@@ -581,7 +581,7 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 	 */
 	public function get_percentage_complete() {
 
-		$total = count( $this->csv->data );
+		$total = count( $this->csv );
 
 		if( $total > 0 ) {
 			$percentage = ( $this->step * $this->per_step / $total ) * 100;

--- a/includes/admin/import/class-batch-import-payments.php
+++ b/includes/admin/import/class-batch-import-payments.php
@@ -558,7 +558,8 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 					$price = trim( $d[1] );
 				}
 
-				$tax   = isset( $matches[1][0] ) ? trim( $matches[1][0] ) : 0;
+				$price    = floatval( $price );
+				$tax      = isset( $matches[1][0] ) ? floatval( trim( $matches[1][0] ) ) : 0;
 				$price_id = isset( $matches[1][1] ) ? trim( $matches[1][1] ) : false;
 
 				$d_array[] = array(


### PR DESCRIPTION
Fixes #9033

Proposed Changes:
This is nearly identical to #8457, with a couple specific differences:
1. Per Chris, we are not removing the ParseCSV library file in case any extensions may be trying to load it. It is removed in 3.0.
2. The since version on the `get_csv_file` method is marked as 2.11.5 instead of 3.0.
3. When importing payments, I encountered a job-stopping error when `$customer` and `$email` were not defined, and then `$customer_by_email`. I think that method is difficult to read but I did the minimum I could do to prevent the errors.