### PR TITLE
Check for $found_key value before checking for array key

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -714,7 +714,7 @@ function edd_get_payment_status( $payment, $return_label = false ) {
 	} else {
 		$keys      = edd_get_payment_status_keys();
 		$found_key = array_search( strtolower( $payment->status ), $keys );
-		$status    = array_key_exists( $found_key, $keys ) ? $keys[ $found_key ] : false;
+		$status    = $found_key && array_key_exists( $found_key, $keys ) ? $keys[ $found_key ] : false;
 	}
 
 	return ! empty( $status ) ? $status : false;


### PR DESCRIPTION
Fixes #9026

Proposed Changes:
1. Just combines the `array_key_exists` check with checking if `$found_key` has a value first.