### PR TITLE
Check if current product section can show before hiding submit button

### DIFF
--- a/includes/admin/extensions/abstract-extension.php
+++ b/includes/admin/extensions/abstract-extension.php
@@ -337,6 +337,9 @@ abstract class Extension {
 	 * @return void
 	 */
 	public function hide_submit_button() {
+		if ( ! $this->can_show_product_section() ) {
+			return;
+		}
 		?>
 		<style>p.submit{display:none;}</style>
 		<?php


### PR DESCRIPTION
Fixes #9042
Currently based off of master.

Proposed Changes:
1. Adds `can_show_product_section` check to the `hide_submit_button` method.