### PR TITLE
Pass modified tabs to navigation function #9045

### DIFF
--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -65,13 +65,12 @@ add_action( 'admin_notices', 'edd_admin_header', 1 );
  * Output the primary options page navigation
  *
  * @since 3.0
- * @param string $active_tab
+ *
+ * @param array  $tabs       All available tabs.
+ * @param string $active_tab Current active tab.
  */
-function edd_options_page_primary_nav( $active_tab = '' ) {
-	$tabs = edd_get_settings_tabs();
-
-	ob_start();?>
-
+function edd_options_page_primary_nav( $tabs, $active_tab = '' ) {
+	?>
 	<nav class="nav-tab-wrapper edd-nav-tab-wrapper edd-settings-nav" aria-label="<?php esc_attr_e( 'Secondary menu', 'easy-digital-downloads' ); ?>">
 		<?php
 
@@ -99,10 +98,7 @@ function edd_options_page_primary_nav( $active_tab = '' ) {
 		}
 		?>
 	</nav>
-
 	<?php
-
-	echo ob_get_clean();
 }
 
 /**
@@ -288,7 +284,7 @@ function edd_options_page() {
 	$settings_tabs  = edd_get_settings_tabs();
 	$settings_tabs  = empty( $settings_tabs ) ? array() : $settings_tabs;
 	$active_tab     = isset( $_GET['tab']   ) ? sanitize_text_field( $_GET['tab'] ) : 'general';
-	$active_tab     = array_key_exists( $active_tab, $settings_tabs ) ? $active_tab : 'general';
+	$active_tab     = array_key_exists( $active_tab, $settings_tabs ) && array_key_exists( $active_tab, $all_settings ) ? $active_tab : 'general';
 	$sections       = edd_get_settings_tab_sections( $active_tab );
 	$section        = ! empty( $_GET['section'] ) && ! empty( $sections[ $_GET['section'] ] ) ? sanitize_text_field( $_GET['section'] ) : 'main';
 
@@ -343,7 +339,7 @@ function edd_options_page() {
 
 		<?php
 		// Primary nav
-		edd_options_page_primary_nav( $active_tab );
+		edd_options_page_primary_nav( $settings_tabs, $active_tab );
 
 		// Secondary nav
 		edd_options_page_secondary_nav( $active_tab, $section, $sections );


### PR DESCRIPTION
Fixes #9045

Proposed Changes:
1. Adds a new required `$tabs` parameter to the `edd_options_page_primary_nav()` function. This function is new in 3.0 so not worried about rearranging parameters. By passing in the tabs instead of re-retrieving them, we get the modified tabs array that's set in `edd_options_page()`. **This change prevents the "Styles" tab from appearing.**
2. Removes the `ob_start()` and `ob_get_clean()` from `edd_options_page_primary_nav()` as I did not feel it was necessary.
3. In `edd_options_page()` I added an extra conditional when setting `$active_tab` to see if it exists in `$all_settings`. **This change protects against the PHP notice in the event that you navigate to `wp-admin/edit.php?post_type=download&page=edd-settings&tab=styles&section=buttons` manually.**