### PR TITLE
Use settings section for UTM medium

### DIFF
--- a/includes/admin/extensions/abstract-extension.php
+++ b/includes/admin/extensions/abstract-extension.php
@@ -35,6 +35,14 @@ abstract class Extension {
 	 */
 	protected $manager;
 
+	/**
+	 * The settings section for this item.
+	 *
+	 * @since 2.11.5
+	 * @var string
+	 */
+	protected $settings_section = 'general';
+
 	public function __construct() {
 		$this->manager = new \EDD\Admin\Extensions\Extension_Manager( static::PASS_LEVEL );
 	}
@@ -267,12 +275,11 @@ abstract class Extension {
 	 * @return string
 	 */
 	private function get_upgrade_url( ProductData $product_data, $item_id, $has_access = false ) {
-		$url            = 'https://easydigitaldownloads.com';
-		$tab            = ! empty( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : '';
+		$url            = 'https://easydigitaldownloads.com/pricing';
 		$utm_parameters = array(
 			'p'            => urlencode( $item_id ),
 			'utm_source'   => 'settings',
-			'utm_medium'   => urlencode( $tab ),
+			'utm_medium'   => urlencode( $this->settings_section ),
 			'utm_campaign' => 'admin',
 			'utm_term'     => urlencode( $product_data->slug ),
 		);

--- a/includes/admin/extensions/product-education/class-email-marketing.php
+++ b/includes/admin/extensions/product-education/class-email-marketing.php
@@ -24,6 +24,14 @@ class EmailMarketing extends Extension {
 	 */
 	protected $settings_tab = 'marketing';
 
+	/**
+	 * The settings section for this item.
+	 *
+	 * @since 2.11.5
+	 * @var string
+	 */
+	protected $settings_section = 'email_marketing';
+
 	public function __construct() {
 		add_filter( 'edd_settings_sections_marketing', array( $this, 'add_section' ) );
 		add_action( 'edd_settings_tab_top_marketing_email_marketing', array( $this, 'field' ) );
@@ -46,7 +54,7 @@ class EmailMarketing extends Extension {
 		if ( ! $product_data || ! is_array( $product_data ) ) {
 			return $sections;
 		}
-		$sections['email_marketing'] = __( 'Email Marketing', 'easy-digital-downloads' );
+		$sections[ $this->settings_section ] = __( 'Email Marketing', 'easy-digital-downloads' );
 
 		return $sections;
 	}

--- a/includes/admin/extensions/product-education/class-invoices.php
+++ b/includes/admin/extensions/product-education/class-invoices.php
@@ -32,6 +32,14 @@ class Invoices extends Extension {
 	protected $settings_tab = 'gateways';
 
 	/**
+	 * The settings section for this item.
+	 *
+	 * @since 2.11.5
+	 * @var string
+	 */
+	protected $settings_section = 'invoices';
+
+	/**
 	 * The pass level required to access this extension.
 	 */
 	const PASS_LEVEL = \EDD\Admin\Pass_Manager::EXTENDED_PASS_ID;
@@ -92,7 +100,7 @@ class Invoices extends Extension {
 			return $sections;
 		}
 
-		$sections['invoices'] = __( 'Invoices', 'easy-digital-downloads' );
+		$sections[ $this->settings_section ] = __( 'Invoices', 'easy-digital-downloads' );
 
 		return $sections;
 	}

--- a/includes/admin/extensions/product-education/class-recurring.php
+++ b/includes/admin/extensions/product-education/class-recurring.php
@@ -36,6 +36,14 @@ class Recurring extends Extension {
 	 */
 	const PASS_LEVEL = \EDD\Admin\Pass_Manager::EXTENDED_PASS_ID;
 
+	/**
+	 * The settings section for this item.
+	 *
+	 * @since 2.11.5
+	 * @var string
+	 */
+	protected $settings_section = 'recurring';
+
 	public function __construct() {
 		add_filter( 'edd_settings_sections_gateways', array( $this, 'add_section' ) );
 		add_action( 'edd_settings_tab_top_gateways_recurring', array( $this, 'settings_field' ) );
@@ -92,7 +100,7 @@ class Recurring extends Extension {
 			return $sections;
 		}
 
-		$sections['recurring'] = __( 'Recurring Payments', 'easy-digital-downloads' );
+		$sections[ $this->settings_section ] = __( 'Recurring Payments', 'easy-digital-downloads' );
 
 		return $sections;
 	}

--- a/includes/admin/extensions/product-education/class-reviews.php
+++ b/includes/admin/extensions/product-education/class-reviews.php
@@ -32,6 +32,14 @@ class Reviews extends Extension {
 	protected $settings_tab = 'marketing';
 
 	/**
+	 * The settings section for this item.
+	 *
+	 * @since 2.11.5
+	 * @var string
+	 */
+	protected $settings_section = 'reviews';
+
+	/**
 	 * The pass level required to access this extension.
 	 */
 	const PASS_LEVEL = \EDD\Admin\Pass_Manager::EXTENDED_PASS_ID;
@@ -97,7 +105,7 @@ class Reviews extends Extension {
 			return $sections;
 		}
 
-		$sections['reviews'] = __( 'Reviews', 'easy-digital-downloads' );
+		$sections[ $this->settings_section ] = __( 'Reviews', 'easy-digital-downloads' );
 
 		return $sections;
 	}


### PR DESCRIPTION
Proposed Changes:
1. Creates a `settings_section` property in the abstract extension class. It's set to `general` by default but should always be overridden.
2. Updates email marketing, Invoices, Reviews, and Recurring to use the new property.
3. Also updates the default upgrade URL to include `/pricing` so that it goes directly to the pricing page instead of the front page.