### PR TITLE
Update stats get_earnings method to correctly query for a single download

### DIFF
--- a/includes/payments/class-payment-stats.php
+++ b/includes/payments/class-payment-stats.php
@@ -276,8 +276,8 @@ class EDD_Payment_Stats extends EDD_Stats {
 				$statuses = apply_filters( 'edd_payment_stats_post_statuses', $statuses );
 				$statuses = "'" . implode( "', '", $statuses ) . "'";
 
-				$results = $wpdb->get_results( $wpdb->prepare(
-					"SELECT edd_oi.tax, edd_oi.total
+				$result = $wpdb->get_row( $wpdb->prepare(
+					"SELECT SUM(edd_oi.tax) as tax, SUM(edd_oi.total) as total
 					 FROM {$wpdb->edd_order_items} edd_oi
 					 INNER JOIN {$wpdb->edd_orders} edd_o ON edd_oi.order_id = edd_o.id
 					 WHERE edd_o.status IN ($statuses) AND edd_oi.product_id = %d {$date_query_sql}",
@@ -285,13 +285,11 @@ class EDD_Payment_Stats extends EDD_Stats {
 
 				$earnings = 0;
 
-				if ( $results ) {
-					foreach ( $results as $result ) {
-						$earnings += floatval( $result->total );
+				if ( $result ) {
+					$earnings += floatval( $result->total );
 
-						if ( ! $include_taxes ) {
-							$earnings -= floatval( $result->tax );
-						}
+					if ( ! $include_taxes ) {
+						$earnings -= floatval( $result->tax );
 					}
 
 					$earnings = apply_filters_deprecated( 'edd_payment_stats_item_earnings', array( $earnings ), 'EDD 3.0' );

--- a/includes/payments/class-payment-stats.php
+++ b/includes/payments/class-payment-stats.php
@@ -276,7 +276,7 @@ class EDD_Payment_Stats extends EDD_Stats {
 				$statuses = apply_filters( 'edd_payment_stats_post_statuses', $statuses );
 				$statuses = "'" . implode( "', '", $statuses ) . "'";
 
-				$result = $wpdb->get_row( $wpdb->prepare(
+				$results = $wpdb->get_results( $wpdb->prepare(
 					"SELECT edd_oi.tax, edd_oi.total
 					 FROM {$wpdb->edd_order_items} edd_oi
 					 INNER JOIN {$wpdb->edd_orders} edd_o ON edd_oi.order_id = edd_o.id
@@ -285,11 +285,13 @@ class EDD_Payment_Stats extends EDD_Stats {
 
 				$earnings = 0;
 
-				if ( $result ) {
-					$earnings += floatval( $result->total );
+				if ( $results ) {
+					foreach ( $results as $result ) {
+						$earnings += floatval( $result->total );
 
-					if ( ! $include_taxes ) {
-						$earnings -= floatval( $result->tax );
+						if ( ! $include_taxes ) {
+							$earnings -= floatval( $result->tax );
+						}
 					}
 
 					$earnings = apply_filters_deprecated( 'edd_payment_stats_item_earnings', array( $earnings ), 'EDD 3.0' );

--- a/tests/tests-stats.php
+++ b/tests/tests-stats.php
@@ -23,11 +23,19 @@ class Tests_Stats extends EDD_UnitTestCase {
 	protected static $order;
 
 	/**
+	 * Second Order fixture.
+	 *
+	 * @var EDD\Orders\Order
+	 */
+	protected static $order2;
+
+	/**
 	 * Set up fixtures once.
 	 */
 	public static function wpSetUpBeforeClass() {
-		self::$stats = new EDD_Payment_Stats();
-		self::$order = parent::edd()->order->create_and_get();
+		self::$stats  = new EDD_Payment_Stats();
+		self::$order  = parent::edd()->order->create_and_get();
+		self::$order2 = parent::edd()->order->create_and_get();
 	}
 
 	public function test_predefined_date_rages() {
@@ -86,44 +94,44 @@ class Tests_Stats extends EDD_UnitTestCase {
 		$this->assertInstanceOf( 'WP_Error', self::$stats->end_date );
 	}
 
-	public function test_get_earnings_for_this_month_should_be_120() {
+	public function test_get_earnings_for_this_month_should_be_240() {
 		$earnings = self::$stats->get_earnings( 0, 'this_month' );
 
-		$this->assertSame( 120.0, $earnings );
+		$this->assertSame( 240.0, $earnings );
 	}
 
-	public function test_get_earnings_for_this_month_excluding_taxes_should_be_95() {
+	public function test_get_earnings_for_this_month_excluding_taxes_should_be_190() {
 		$earnings = self::$stats->get_earnings( 0, 'this_month', false, false );
 
-		$this->assertSame( 95.0, $earnings );
+		$this->assertSame( 190.0, $earnings );
 	}
 
-	public function test_get_earnings_for_this_month_for_download_should_return_120() {
+	public function test_get_earnings_for_this_month_for_download_should_return_240() {
 		$earnings = self::$stats->get_earnings( 1, 'this_month' );
-		$this->assertEquals( 120.0, $earnings );
+		$this->assertEquals( 240.0, $earnings );
 	}
 
-	public function test_get_earnings_for_this_month_for_download_excluding_taxes_should_return_95() {
+	public function test_get_earnings_for_this_month_for_download_excluding_taxes_should_return_190() {
 		$earnings = self::$stats->get_earnings( 1, 'this_month', false, false );
-		$this->assertEquals( 95.0, $earnings );
+		$this->assertEquals( 190.0, $earnings );
 	}
 
-	public function test_get_sales_for_this_month_should_be_1() {
+	public function test_get_sales_for_this_month_should_be_2() {
 		$sales = self::$stats->get_sales( 0, 'this_month' );
 
-		$this->assertSame( 1, $sales );
+		$this->assertSame( 2, $sales );
 	}
 
-	public function test_get_sales_for_this_month_for_download_should_return_1() {
+	public function test_get_sales_for_this_month_for_download_should_return_2() {
 		$earnings = self::$stats->get_sales( 1, 'this_month' );
-		$this->assertEquals( 1, $earnings );
+		$this->assertEquals( 2, $earnings );
 	}
 
 	public function test_get_sales_by_range_for_today() {
 		$sales = self::$stats->get_sales_by_range( 'today' );
 
 		$this->assertNotEmpty( $sales );
-		$this->assertEquals( 1, $sales[0]['count'] );
+		$this->assertEquals( 2, $sales[0]['count'] );
 		$this->assertEquals( date( 'Y' ), $sales[0]['y'] );
 	}
 }


### PR DESCRIPTION
Fixes #9070

Proposed Changes:
1. Updates the `get_earnings` method in the payment stats class to use `$wpdb->get_results()` and then add up the results ... I don't know if it's possible to get the `SUM` of two columns in a single query--if so, that might would be more efficient.
2. I also updated the stats unit tests to run two orders and get the data from them. This could be improved by generating a distinctly different order instead of just duplicating the one that's there. But with the current release code, `test_get_earnings_for_this_month_for_download_should_return_240` and `test_get_earnings_for_this_month_for_download_excluding_taxes_should_return_190` would fail, I think.
