### PR TITLE
Update logic for showing currency filter on reports

### DIFF
--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -1229,7 +1229,7 @@ function display_currency_filter() {
 		set_transient( 'edd_distinct_order_currencies', $order_currencies, 3 * HOUR_IN_SECONDS );
 	}
 
-	if ( ! is_array( $order_currencies ) || 1 === count( $order_currencies ) ) {
+	if ( ! is_array( $order_currencies ) || count( $order_currencies ) <= 1 ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #9072

Proposed Changes:
1. The `display_currency_filter` currently counts how many currencies are represented in the EDD store orders and displays the filter if the number is not _equal_ to 1. However, the `$wpdb` result can be an empty array when there are no orders, so the count comparison should factor that in. This PR changes the `===` to a less than or equal to comparison.