### PR TITLE
Add unit tests for edd_is_cart_empty()

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -385,10 +385,10 @@ function edd_get_cart_fee_tax() {
 }
 
 /**
- * is the cart empty?
+ * Is the cart empty?
  *
  * @since 3.0
- * @uses EDD()->fees->is_empty()
+ * @uses EDD()->cart->is_empty()
  * @return bool Is the cart empty?
  */
 function edd_is_cart_empty() {

--- a/tests/tests-cart.php
+++ b/tests/tests-cart.php
@@ -212,7 +212,6 @@ class Test_Cart extends EDD_UnitTestCase {
 
 		$this->assertInternalType( 'array', $cart_contents );
 		$this->assertEmpty( $cart_contents );
-		$this->assertTrue( edd_is_cart_empty() );
 	}
 
 	public function test_add_to_cart_multiple_price_ids_array() {
@@ -263,7 +262,6 @@ class Test_Cart extends EDD_UnitTestCase {
 		);
 
 		$this->assertEquals( $expected, edd_get_cart_contents() );
-		$this->assertFalse( edd_is_cart_empty() );
 	}
 
 	public function test_get_cart_content_details() {
@@ -597,7 +595,6 @@ class Test_Cart extends EDD_UnitTestCase {
 		edd_update_option( 'enable_cart_saving', '1' );
 		$this->assertTrue( edd_restore_cart() );
 		$this->assertEquals( edd_get_cart_contents(), $saved_cart );
-		$this->assertFalse( edd_is_cart_empty() );
 	}
 
 	public function test_generate_cart_token() {
@@ -726,10 +723,12 @@ class Test_Cart extends EDD_UnitTestCase {
 	}
 
 	public function test_cart_is_empty() {
-		edd_add_to_cart( self::$download->ID, array( 'price_id' => 0 ) );
-		$this->assertFalse( edd_is_cart_empty() );
-
 		edd_empty_cart();
 		$this->assertTrue( edd_is_cart_empty() );
+	}
+
+	public function test_cart_is_not_empty() {
+		edd_add_to_cart( self::$download->ID, array( 'price_id' => 0 ) );
+		$this->assertFalse( edd_is_cart_empty() );
 	}
 }

--- a/tests/tests-cart.php
+++ b/tests/tests-cart.php
@@ -212,6 +212,7 @@ class Test_Cart extends EDD_UnitTestCase {
 
 		$this->assertInternalType( 'array', $cart_contents );
 		$this->assertEmpty( $cart_contents );
+		$this->assertTrue( edd_is_cart_empty() );
 	}
 
 	public function test_add_to_cart_multiple_price_ids_array() {
@@ -262,6 +263,7 @@ class Test_Cart extends EDD_UnitTestCase {
 		);
 
 		$this->assertEquals( $expected, edd_get_cart_contents() );
+		$this->assertFalse( edd_is_cart_empty() );
 	}
 
 	public function test_get_cart_content_details() {
@@ -595,6 +597,7 @@ class Test_Cart extends EDD_UnitTestCase {
 		edd_update_option( 'enable_cart_saving', '1' );
 		$this->assertTrue( edd_restore_cart() );
 		$this->assertEquals( edd_get_cart_contents(), $saved_cart );
+		$this->assertFalse( edd_is_cart_empty() );
 	}
 
 	public function test_generate_cart_token() {
@@ -720,5 +723,13 @@ class Test_Cart extends EDD_UnitTestCase {
 		$this->assertEquals( 1.00, EDD()->cart->get_tax() );
 
 		edd_update_option( 'enable_taxes', false );
+	}
+
+	public function test_cart_is_empty() {
+		edd_add_to_cart( self::$download->ID, array( 'price_id' => 0 ) );
+		$this->assertFalse( edd_is_cart_empty() );
+
+		edd_empty_cart();
+		$this->assertTrue( edd_is_cart_empty() );
 	}
 }


### PR DESCRIPTION
Proposed Changes:
1. Adds a new unit test, `test_cart_is_empty`, with two assertions.
2. Adds a test for `edd_is_cart_empty()` (true) to `test_empty_cart_is_array`.
3. Adds a test for `edd_is_cart_empty()` (false) to `test_get_cart_contents`.
4. Adds a test for `edd_is_cart_empty()` (false) to `test_restore_cart`.