### PR TITLE
Do not run edd_complete_purchase on refunds

### DIFF
--- a/includes/orders/functions/refunds.php
+++ b/includes/orders/functions/refunds.php
@@ -394,6 +394,7 @@ function edd_refund_order( $order_id, $order_items = 'all', $adjustments = 'all'
 
 	edd_update_order( $order_id, array( 'status' => $order_status ) );
 
+	edd_update_order( $refund_id, array( 'date_completed' => date( 'Y-m-d H:i:s' ) ) );
 	/**
 	 * Fires when an order has been refunded.
 	 * This hook will trigger the legacy `edd_pre_refund_payment` and `edd_post_refund_payment`

--- a/includes/payments/actions.php
+++ b/includes/payments/actions.php
@@ -27,19 +27,20 @@ if ( !defined( 'ABSPATH' ) ) exit;
 */
 function edd_complete_purchase( $order_id, $new_status, $old_status ) {
 
+	$completed_statuses = array( 'publish', 'complete', 'completed' );
 	// Make sure that payments are only completed once.
-	if ( 'publish' === $old_status || 'complete' === $old_status || 'completed' === $old_status ) {
+	if ( in_array( $old_status, $completed_statuses, true ) ) {
 		return;
 	}
 
 	// Make sure the payment completion is only processed when new status is complete.
-	if ( 'publish' !== $new_status && 'complete' !== $new_status && 'completed' !== $new_status ) {
+	if ( ! in_array( $new_status, $completed_statuses, true ) ) {
 		return;
 	}
 
 	$order = edd_get_order( $order_id );
 
-	if ( ! $order ) {
+	if ( ! $order || 'sale' !== $order->type ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #9031

Proposed Changes:
1. Adds a check for the order `type` during `edd_complete_purchase` and exits early if the order is not a sale.
2. Additionally updates the refund order completed date at the end of `edd_refund_order` (with the first change, the refund was not getting a completed date).
 
Note that with this change, refund orders no longer have a `date_refundable` value added to the database, which seems appropriate.