### PR TITLE
Update WordPress versions for buildkite tests

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -7,10 +7,10 @@ set -eu
 echo "steps:"
 
 phpVersions=('5.6' '7.0' '7.1' '7.2' '7.3' '7.4')
-wpVersions=('4.9.15' '5.0.10' '5.1.6' '5.2.7' '5.3.4' '5.4.2' '5.5.3' '5.6.3' 'latest')
+wpVersions=('4.9.19' '5.0.15' '5.1.12' '5.2.14' '5.3.11' '5.4.9' '5.5.8' '5.6.7' '5.7.5' '5.8.3' 'latest')
 
 # Exclude combinations with <php version>-<wp version>
-exclusions=('7.3-4.9.15' '7.4-4.9.15' '7.4-5.0.10' '7.4-5.1.6' '7.4-5.2.7')
+exclusions=('7.3-4.9.19' '7.4-4.9.19' '7.4-5.0.15' '7.4-5.1.12' '7.4-5.2.14')
 
 # add a new command step to run the tests in each test directory
 for phpVersion in ${phpVersions[@]}; do


### PR DESCRIPTION
Adds WP 5.7,5.8 to tested WordPress versions.
