### PR TITLE
Disallow buy now button if purchasing multiple options is enabled

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -85,7 +85,7 @@ function edd_get_purchase_link( $args = array() ) {
 	$args = wp_parse_args( $args, $defaults );
 
 	// Override the straight_to_gateway if the shop doesn't support it
-	if ( ! edd_shop_supports_buy_now() ) {
+	if ( ! edd_shop_supports_buy_now() || edd_single_price_option_mode( $args['download_id'] ) ) {
 		$args['direct'] = false;
 	}
 


### PR DESCRIPTION
Fixes #5018

Proposed Changes:
1. This disallows the buy now button if the multi-purchase option is enabled for a download.