### PR TITLE
Update order stats class to use null, remove empty checks

### DIFF
--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -122,7 +122,7 @@ class Stats {
 				'relative_end'      => '',
 				'grouped'           => false,
 				'product_id'        => '',
-				'price_id'          => '',
+				'price_id'          => null,
 			);
 		}
 
@@ -574,9 +574,7 @@ class Stats {
 			? $this->get_db()->prepare( 'AND product_id = %d', absint( $this->query_vars['product_id'] ) )
 			: '';
 
-		$price_id = ! empty( $this->query_vars['price_id'] )
-			? $this->get_db()->prepare( 'AND price_id = %d', absint( $this->query_vars['price_id'] ) )
-			: '';
+		$price_id = $this->generate_price_id_query_sql();
 
 		$currency_sql = str_replace( $this->get_db()->edd_order_items, $this->get_db()->edd_orders, $this->query_vars['currency_sql'] );
 
@@ -611,7 +609,7 @@ class Stats {
 
 				// Format resultant object.
 				$value->product_id = absint( $value->product_id );
-				$value->price_id   = absint( $value->price_id );
+				$value->price_id   = is_numeric( $value->price_id ) ? absint( $value->price_id ) : null;
 				$value->total      = absint( $value->total );
 
 				// Add instance of EDD_Download to resultant object.
@@ -902,9 +900,7 @@ class Stats {
 			? $this->get_db()->prepare( 'AND product_id = %d', absint( $this->query_vars['product_id'] ) )
 			: '';
 
-		$price_id = ! empty( $this->query_vars['price_id'] )
-			? $this->get_db()->prepare( 'AND price_id = %d', absint( $this->query_vars['price_id'] ) )
-			: '';
+		$price_id = $this->generate_price_id_query_sql();
 
 		$region = ! empty( $this->query_vars['region'] )
 			? $this->get_db()->prepare( 'AND edd_oa.region = %s', esc_sql( $this->query_vars['region'] ) )
@@ -944,7 +940,7 @@ class Stats {
 
 				// Format resultant object.
 				$value->product_id = absint( $value->product_id );
-				$value->price_id   = absint( $value->price_id );
+				$value->price_id   = is_numeric( $value->price_id ) ? absint( $value->price_id ) : null;
 				$value->total      = $this->maybe_format( $value->total );
 
 				// Add instance of EDD_Download to resultant object.
@@ -1009,9 +1005,7 @@ class Stats {
 			? $this->get_db()->prepare( 'AND product_id = %d', absint( $this->query_vars['product_id'] ) )
 			: '';
 
-		$price_id = ! empty( $this->query_vars['price_id'] )
-			? $this->get_db()->prepare( 'AND price_id = %d', absint( $this->query_vars['price_id'] ) )
-			: '';
+		$price_id = $this->generate_price_id_query_sql();
 
 		$region = ! empty( $this->query_vars['region'] )
 			? $this->get_db()->prepare( 'AND edd_oa.region = %s', esc_sql( $this->query_vars['region'] ) )
@@ -1061,7 +1055,7 @@ class Stats {
 
 				// Format resultant object.
 				$value->product_id = absint( $value->product_id );
-				$value->price_id   = absint( $value->price_id );
+				$value->price_id   = is_numeric( $value->price_id ) ? absint( $value->price_id ) : null;
 				$value->total      = absint( $value->total );
 
 				// Add instance of EDD_Download to resultant object.
@@ -1151,7 +1145,7 @@ class Stats {
 
 			// Format resultant object.
 			$value->product_id = absint( $value->product_id );
-			$value->price_id   = absint( $value->price_id );
+			$value->price_id   = is_numeric( $value->price_id ) ? absint( $value->price_id ) : null;
 			$value->sales      = absint( $value->sales );
 			$value->total      = $this->maybe_format( $value->total );
 
@@ -1795,9 +1789,7 @@ class Stats {
 			? $this->get_db()->prepare( 'AND product_id = %d', absint( $this->query_vars['download_id'] ) )
 			: '';
 
-		$price_id = ! empty( $this->query_vars['price_id'] )
-			? $this->get_db()->prepare( 'AND price_id = %d', absint( $this->query_vars['price_id'] ) )
-			: '';
+		$price_id = $this->generate_price_id_query_sql();
 
 		if ( true === $this->query_vars['relative'] ) {
 			$relative_date_query_sql = $this->generate_relative_date_query_sql();
@@ -1922,7 +1914,7 @@ class Stats {
 			? $this->get_db()->prepare( 'AND oi.product_id = %d', absint( $this->query_vars['download_id'] ) )
 			: '';
 
-		$price_id = ! empty( $this->query_vars['price_id'] )
+		$price_id = ! is_null( $this->query_vars['price_id'] ) && is_numeric( $this->query_vars['price_id'] )
 			? $this->get_db()->prepare( 'AND oi.price_id = %d', absint( $this->query_vars['price_id'] ) )
 			: '';
 
@@ -2408,9 +2400,7 @@ class Stats {
 			? $this->get_db()->prepare( 'AND product_id = %d', absint( $this->query_vars['download_id'] ) )
 			: '';
 
-		$price_id = ! empty( $this->query_vars['price_id'] )
-			? $this->get_db()->prepare( 'AND price_id = %d', absint( $this->query_vars['price_id'] ) )
-			: '';
+		$price_id = $this->generate_price_id_query_sql();
 
 		if ( true === $this->query_vars['relative'] ) {
 			$relative_date_query_sql = $this->generate_relative_date_query_sql();
@@ -2568,9 +2558,7 @@ class Stats {
 			? $this->get_db()->prepare( 'AND product_id = %d', absint( $this->query_vars['download_id'] ) )
 			: '';
 
-		$price_id = ! empty( $this->query_vars['price_id'] )
-			? $this->get_db()->prepare( 'AND price_id = %d', absint( $this->query_vars['price_id'] ) )
-			: '';
+		$price_id = $this->generate_price_id_query_sql();
 
 		$file_id = ! empty( $this->query_vars['file_id'] )
 			? $this->get_db()->prepare( 'AND file_id = %d', absint( $this->query_vars['file_id'] ) )
@@ -2632,7 +2620,7 @@ class Stats {
 			'relative_end'      => '',
 			'grouped'           => false,
 			'product_id'        => '',
-			'price_id'          => '',
+			'price_id'          => null,
 			'country'           => '',
 			'region'            => '',
 		);
@@ -2912,6 +2900,18 @@ class Stats {
 
 			return $date_query_sql;
 		}
+	}
+
+	/**
+	 * Generates price ID query SQL.
+	 *
+	 * @since 3.0
+	 * @return string
+	 */
+	private function generate_price_id_query_sql() {
+		return ! is_null( $this->query_vars['price_id'] ) && is_numeric( $this->query_vars['price_id'] )
+			? $this->get_db()->prepare( 'AND price_id = %d', absint( $this->query_vars['price_id'] ) )
+			: '';
 	}
 
 	/** Private Getters *******************************************************/

--- a/tests/orders/tests-stats.php
+++ b/tests/orders/tests-stats.php
@@ -43,6 +43,23 @@ class Stats_Tests extends \EDD_UnitTestCase {
 		for ( $i = 0; $i < 2; $i++ ) {
 			self::$refunds[] = edd_refund_order( self::$orders[ $i ] );
 		}
+
+		// Add a variable download with price ID 0 to order 3.
+		edd_add_order_item(
+			array(
+				'order_id'     => 3,
+				'product_id'   => 2,
+				'price_id'     => 0,
+				'product_name' => 'Variable Test Download Product - Simple',
+				'status'       => 'complete',
+				'amount'       => 20,
+				'subtotal'     => 20,
+				'discount'     => 0,
+				'tax'          => 0,
+				'total'        => 20,
+				'quantity'     => 1,
+			)
+		);
 	}
 
 	/**
@@ -176,6 +193,19 @@ class Stats_Tests extends \EDD_UnitTestCase {
 	/**
 	 * @covers ::get_order_item_count
 	 */
+	public function test_get_order_item_count_no_price_id_should_be_2() {
+		$count = self::$stats->get_order_item_count(
+			array(
+				'product_id' => 1,
+			)
+		);
+
+		$this->assertSame( 2, $count );
+	}
+
+	/**
+	 * @covers ::get_order_item_count
+	 */
 	public function test_get_order_item_count_null_price_id_should_be_2() {
 		$count = self::$stats->get_order_item_count(
 			array(
@@ -204,15 +234,15 @@ class Stats_Tests extends \EDD_UnitTestCase {
 	/**
 	 * @covers ::get_order_item_count
 	 */
-	public function test_get_order_item_count_zero_price_id_should_be_0() {
+	public function test_get_order_item_count_zero_price_id_should_be_1() {
 		$count = self::$stats->get_order_item_count(
 			array(
-				'product_id' => 1,
+				'product_id' => 2,
 				'price_id'   => 0,
 			)
 		);
 
-		$this->assertSame( 0, $count );
+		$this->assertSame( 1, $count );
 	}
 
 	/**

--- a/tests/orders/tests-stats.php
+++ b/tests/orders/tests-stats.php
@@ -174,6 +174,48 @@ class Stats_Tests extends \EDD_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::get_order_item_count
+	 */
+	public function test_get_order_item_count_null_price_id_should_be_2() {
+		$count = self::$stats->get_order_item_count(
+			array(
+				'product_id' => 1,
+				'price_id'   => null,
+			)
+		);
+
+		$this->assertSame( 2, $count );
+	}
+
+	/**
+	 * @covers ::get_order_item_count
+	 */
+	public function test_get_order_item_count_invalid_price_id_should_be_0() {
+		$count = self::$stats->get_order_item_count(
+			array(
+				'product_id' => 1,
+				'price_id'   => 2,
+			)
+		);
+
+		$this->assertSame( 0, $count );
+	}
+
+	/**
+	 * @covers ::get_order_item_refund_count
+	 */
+	public function test_get_order_item_refund_count_with_invalid_price_id_should_be_0() {
+		$count = self::$stats->get_order_item_refund_count(
+			array(
+				'product_id' => 1,
+				'price_id'   => 2,
+			)
+		);
+
+		$this->assertSame( 0, $count );
+	}
+
+	/**
 	 * @covers ::get_order_refund_amount
 	 */
 	public function test_get_order_refund_amount_with_range_last_year_should_be_0() {

--- a/tests/orders/tests-stats.php
+++ b/tests/orders/tests-stats.php
@@ -202,6 +202,20 @@ class Stats_Tests extends \EDD_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::get_order_item_count
+	 */
+	public function test_get_order_item_count_zero_price_id_should_be_0() {
+		$count = self::$stats->get_order_item_count(
+			array(
+				'product_id' => 1,
+				'price_id'   => 0,
+			)
+		);
+
+		$this->assertSame( 0, $count );
+	}
+
+	/**
 	 * @covers ::get_order_item_refund_count
 	 */
 	public function test_get_order_item_refund_count_with_invalid_price_id_should_be_0() {


### PR DESCRIPTION
Fixes #9122

Proposed Changes:
1. Sets the `price_id` default to `null` instead of an empty string.
2. Creates `generate_price_id_query_sql` method to check the price ID and generate the SQL query string.
3. In places where a price ID is cast to an absolute value, check if it's numeric first--if numeric, cast as before; if not, set to `null` instead.