### PR TITLE
Create edd_get_download_taxonomies helper function

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -2843,7 +2843,7 @@ function display_export_report() {
 						<p><?php printf( esc_html__( 'Download a CSV of customers. Select a taxonomy to see all the customers who purchased %s in that taxonomy.', 'easy-digital-downloads' ), edd_get_label_plural( true ) ); ?></p>
 						<form id="edd-export-customers" class="edd-export-form edd-import-export-form" method="post">
 							<?php
-							$taxonomies = get_object_taxonomies( 'download', 'names' );
+							$taxonomies = edd_get_download_taxonomies();
 							$taxonomies = array_map( 'sanitize_text_field', $taxonomies );
 
 							$placeholders = implode( ', ', array_fill( 0, count( $taxonomies ), '%s' ) );

--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -311,6 +311,22 @@ function edd_setup_download_taxonomies() {
 add_action( 'init', 'edd_setup_download_taxonomies', 0 );
 
 /**
+ * Gets the names for the default download taxonomies.
+ *
+ * @since 3.0
+ * @return array
+ */
+function edd_get_download_taxonomies() {
+	return apply_filters(
+		'edd_download_taxonomies',
+		array(
+			'download_category',
+			'download_tag',
+		)
+	);
+}
+
+/**
  * Get the singular and plural labels for a download taxonomy
  *
  * @since  2.4

--- a/includes/reports/data/downloads/class-earnings-by-taxonomy-list-table.php
+++ b/includes/reports/data/downloads/class-earnings-by-taxonomy-list-table.php
@@ -55,7 +55,7 @@ class Earnings_By_Taxonomy_List_Table extends List_Table {
 			}
 		}
 
-		$taxonomies = get_object_taxonomies( 'download', 'names' );
+		$taxonomies = edd_get_download_taxonomies();
 		$taxonomies = array_map( 'sanitize_text_field', $taxonomies );
 
 		$placeholders = implode( ', ', array_fill( 0, count( $taxonomies ), '%s' ) );


### PR DESCRIPTION
Fixes #9124

Proposed Changes:
1. Creates the `edd_get_download_taxonomies` helper function, which will, by default, return only the `download_category` and `download_tag` taxonomy names.
2. Applies a filter to the array so a developer can manually add a custom taxonomy to the array.
3. Updates the customer export and the taxonomy earnings table to use this new helper function.