### PR TITLE
Try/categories api endpoint

### DIFF
--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -76,7 +76,7 @@ function edd_setup_edd_post_types() {
 		'has_archive'        => $archives,
 		'hierarchical'       => false,
 		'show_in_rest'       => true,
-		'rest_base'          => 'edd/downloads',
+		'rest_base'          => 'edd-downloads',
 		'supports'           => apply_filters( 'edd_download_supports', array( 'title', 'editor', 'thumbnail', 'excerpt', 'revisions', 'author' ) ),
 	);
 	register_post_type( 'download', apply_filters( 'edd_download_post_type_args', $download_args ) );
@@ -266,7 +266,7 @@ function edd_setup_download_taxonomies() {
 			'query_var'    => 'download_category',
 			'rewrite'      => array( 'slug' => $slug . '/category', 'with_front' => false, 'hierarchical' => true ),
 			'show_in_rest'          => true,
-			'rest_base'             => 'edd/categories',
+			'rest_base'             => 'edd-categories',
 			'rest_controller_class' => 'WP_REST_Terms_Controller',
 			'capabilities' => array(
 				'manage_terms' => 'manage_product_terms',
@@ -302,7 +302,7 @@ function edd_setup_download_taxonomies() {
 			'query_var'    => 'download_tag',
 			'rewrite'      => array( 'slug' => $slug . '/tag', 'with_front' => false, 'hierarchical' => true ),
 			'show_in_rest'          => true,
-			'rest_base'             => 'edd/tags',
+			'rest_base'             => 'edd-tags',
 			'rest_controller_class' => 'WP_REST_Terms_Controller',
 			'capabilities' => array(
 				'manage_terms' => 'manage_product_terms',

--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -75,6 +75,8 @@ function edd_setup_edd_post_types() {
 		'map_meta_cap'       => true,
 		'has_archive'        => $archives,
 		'hierarchical'       => false,
+		'show_in_rest'       => true,
+		'rest_base'          => 'edd/downloads',
 		'supports'           => apply_filters( 'edd_download_supports', array( 'title', 'editor', 'thumbnail', 'excerpt', 'revisions', 'author' ) ),
 	);
 	register_post_type( 'download', apply_filters( 'edd_download_post_type_args', $download_args ) );
@@ -263,6 +265,9 @@ function edd_setup_download_taxonomies() {
 			'show_ui'      => true,
 			'query_var'    => 'download_category',
 			'rewrite'      => array( 'slug' => $slug . '/category', 'with_front' => false, 'hierarchical' => true ),
+			'show_in_rest'          => true,
+			'rest_base'             => 'edd/categories',
+			'rest_controller_class' => 'WP_REST_Terms_Controller',
 			'capabilities' => array(
 				'manage_terms' => 'manage_product_terms',
 				'edit_terms'   => 'edit_product_terms',
@@ -296,6 +301,9 @@ function edd_setup_download_taxonomies() {
 			'show_ui'      => true,
 			'query_var'    => 'download_tag',
 			'rewrite'      => array( 'slug' => $slug . '/tag', 'with_front' => false, 'hierarchical' => true ),
+			'show_in_rest'          => true,
+			'rest_base'             => 'edd/tags',
+			'rest_controller_class' => 'WP_REST_Terms_Controller',
 			'capabilities' => array(
 				'manage_terms' => 'manage_product_terms',
 				'edit_terms'   => 'edit_product_terms',


### PR DESCRIPTION
Included changes:
1. Adds `edd-downloads` to the Rest API: `wp-json/wp/v2/edd-downloads`
2. Adds `edd-categories` to the Rest API: `wp-json/wp/v2/edd-categories`
3. Adds `edd-tags` to the Rest API: `wp-json/wp/v2/edd-tags`

In addition, allows filtering downloads via these taxonomies with:
`wp-json/wp/v2/edd-downloads?edd-categories=<category_id>`
`wp-json/wp/v2/edd-downloads?edd-tags=<tag_id>`