### PR TITLE
Add a filter on edd_auto_register_login_user for PayPal Commerce

### DIFF
--- a/includes/gateways/paypal/integrations.php
+++ b/includes/gateways/paypal/integrations.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * PayPal Commerce Integrations
+ *
+ * @package    easy-digital-downloads
+ * @subpackage Gateways\PayPal
+ * @copyright  Copyright (c) 2022, Easy Digital Downloads
+ * @license    GPL2+
+ * @since      3.0
+ */
+
+namespace EDD\Gateways\PayPal;
+
+/**
+ * Tells Auto Register to log the user in when the PayPal Commerce action is detected.
+ * Added slightly early to not override anything more specific.
+ *
+ * @since 3.0
+ * @return bool
+ */
+function auto_register() {
+	return isset( $_POST['action'] ) && 'edd_capture_paypal_order' === $_POST['action'];
+}
+add_filter( 'edd_auto_register_login_user', __NAMESPACE__ . '\auto_register', 5 );

--- a/includes/gateways/paypal/paypal.php
+++ b/includes/gateways/paypal/paypal.php
@@ -68,6 +68,7 @@ require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/webhooks/events/abstract
 require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/webhooks/events/class-payment-capture-completed.php';
 require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/webhooks/events/class-payment-capture-denied.php';
 require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/webhooks/events/class-payment-capture-refunded.php';
+require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/integrations.php';
 
 if ( is_admin() ) {
 	require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/admin/connect.php';


### PR DESCRIPTION
Fixes #9133

Proposed Changes:
1. Adds a filter for `edd_auto_register_login_user` for PayPal Commerce. The usage is consistent with what we do in Stripe.