### PR TITLE
Rename Privacy tab to Policies

### DIFF
--- a/includes/admin/settings/contextual-help.php
+++ b/includes/admin/settings/contextual-help.php
@@ -90,9 +90,9 @@ function edd_settings_contextual_help() {
 	) );
 
 	$screen->add_help_tab( array(
-		'id'		=> 'edd-settings-privacy',
-		'title'		=> __( 'Privacy', 'easy-digital-downloads' ),
-		'content'	=>
+		'id'      => 'edd-settings-privacy',
+		'title'   => __( 'Policies', 'easy-digital-downloads' ),
+		'content' =>
 			'<p>' . __( 'This screen provides access to customer privacy policies, terms & agreements, and how to display them on the front of your site.', 'easy-digital-downloads' ) . '</p>' .
 			'<p>' . __( 'You may also override what happens to order records when a customer exercises their right to be forgotten from your site.',        'easy-digital-downloads' ) . '</p>'
 	) );

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1628,7 +1628,7 @@ function edd_get_settings_tabs() {
 		'marketing'  => __( 'Marketing', 'easy-digital-downloads' ),
 		'styles'     => __( 'Styles', 'easy-digital-downloads' ),
 		'taxes'      => __( 'Taxes', 'easy-digital-downloads' ),
-		'privacy'    => __( 'Privacy', 'easy-digital-downloads' ),
+		'privacy'    => __( 'Policies', 'easy-digital-downloads' ),
 		'extensions' => __( 'Extensions', 'easy-digital-downloads' ),
 		'licenses'   => __( 'Licenses', 'easy-digital-downloads' ),
 		'misc'       => __( 'Misc', 'easy-digital-downloads' ),


### PR DESCRIPTION
Fixes #9136

Proposed Changes:
1. Renames the privacy tab to policies as suggested.
2. Also updates the corresponding help tab.