### PR TITLE
Make sure custom object meta is deleted along with the object

### DIFF
--- a/includes/database/engine/class-query.php
+++ b/includes/database/engine/class-query.php
@@ -2397,9 +2397,12 @@ class Query extends Base {
 			return;
 		}
 
+		// Maybe apply the prefix to the meta type.
+		$meta_type = $this->apply_prefix( $this->item_name );
+
 		// Delete all meta data for this item ID
 		foreach ( $meta_ids as $mid ) {
-			delete_metadata_by_mid( $this->item_name, $mid );
+			delete_metadata_by_mid( $meta_type, $mid );
 		}
 	}
 

--- a/includes/database/engine/class-query.php
+++ b/includes/database/engine/class-query.php
@@ -1133,10 +1133,6 @@ class Query extends Base {
 
 		// Defaults
 		$where = $join = $searchable = $date_query = array();
-		$and   = '/^\s*AND\s*/';
-
-		// Set the table right away
-		$table = $this->apply_prefix( $this->item_name );
 
 		// Loop through columns
 		foreach ( $this->columns as $column ) {
@@ -1276,11 +1272,16 @@ class Query extends Base {
 			$where['search'] = $this->get_search_sql( $this->query_vars['search'], $search_columns );
 		}
 
+		// Get the primary column & table
+		$primary = $this->get_primary_column_name();
+		$table   = $this->get_meta_type();
+		$and     = '/^\s*AND\s*/';
+
 		// Maybe perform a meta query.
 		$meta_query = $this->query_vars['meta_query'];
 		if ( ! empty( $meta_query ) && is_array( $meta_query ) ) {
 			$this->meta_query = $this->get_meta_query( $meta_query );
-			$clauses          = $this->meta_query->get_sql( $table, $this->table_alias, $this->get_primary_column_name(), $this );
+			$clauses          = $this->meta_query->get_sql( $table, $this->table_alias, $primary, $this );
 
 			// Not all objects have meta, so make sure this one exists
 			if ( false !== $clauses ) {
@@ -1301,10 +1302,15 @@ class Query extends Base {
 		$compare_query = $this->query_vars['compare_query'];
 		if ( ! empty( $compare_query ) && is_array( $compare_query ) ) {
 			$this->compare_query = $this->get_compare_query( $compare_query );
-			$clauses             = $this->compare_query->get_sql( $table, $this->table_alias, $this->get_primary_column_name(), $this );
+			$clauses             = $this->compare_query->get_sql( $table, $this->table_alias, $primary, $this );
 
 			// Not all objects can compare, so make sure this one exists
 			if ( false !== $clauses ) {
+
+				// Set join
+				if ( ! empty( $clauses['join'] ) ) {
+					$join['compare_query'] = $clauses['join'];
+				}
 
 				// Remove " AND " from query where clause.
 				$where['compare_query'] = preg_replace( $and, '', $clauses['where'] );
@@ -1319,10 +1325,15 @@ class Query extends Base {
 		// Maybe perform a date query
 		if ( ! empty( $date_query ) && is_array( $date_query ) ) {
 			$this->date_query = $this->get_date_query( $date_query );
-			$clauses          = $this->date_query->get_sql( $table, $this->table_alias, $this->get_primary_column_name(), $this );
+			$clauses          = $this->date_query->get_sql( $this->table_name, $this->table_alias, $primary, $this );
 
 			// Not all objects are dates, so make sure this one exists
 			if ( false !== $clauses ) {
+
+				// Set join
+				if ( ! empty( $clauses['join'] ) ) {
+					$join['date_query'] = $clauses['join'];
+				}
 
 				// Remove " AND " from query where clause.
 				$where['date_query'] = preg_replace( $and, '', $clauses['where'] );
@@ -2198,11 +2209,8 @@ class Query extends Base {
 			return false;
 		}
 
-		// Get meta table name
-		$table = $this->apply_prefix( $this->item_name );
-
 		// Bail if no meta table exists
-		if ( empty( $table ) ) {
+		if ( false === $this->get_meta_table_name() ) {
 			return false;
 		}
 
@@ -2228,16 +2236,16 @@ class Query extends Base {
 			return false;
 		}
 
-		// Get meta table name
-		$table = $this->apply_prefix( $this->item_name );
-
 		// Bail if no meta table exists
-		if ( empty( $table ) ) {
+		if ( false === $this->get_meta_table_name() ) {
 			return false;
 		}
 
-		// Return results of get meta data
-		return get_metadata( $table, $item_id, $meta_key, $single );
+		// Get meta type
+		$meta_type = $this->get_meta_type();
+
+		// Return results of getting meta data
+		return get_metadata( $meta_type, $item_id, $meta_key, $single );
 	}
 
 	/**
@@ -2259,16 +2267,16 @@ class Query extends Base {
 			return false;
 		}
 
-		// Get meta table name
-		$table = $this->apply_prefix( $this->item_name );
-
 		// Bail if no meta table exists
-		if ( empty( $table ) ) {
+		if ( false === $this->get_meta_table_name() ) {
 			return false;
 		}
 
-		// Return results of get meta data
-		return update_metadata( $table, $item_id, $meta_key, $meta_value, $prev_value );
+		// Get meta type
+		$meta_type = $this->get_meta_type();
+
+		// Return results of updating meta data
+		return update_metadata( $meta_type, $item_id, $meta_key, $meta_value, $prev_value );
 	}
 
 	/**
@@ -2290,16 +2298,16 @@ class Query extends Base {
 			return false;
 		}
 
-		// Get meta table name
-		$table = $this->apply_prefix( $this->item_name );
-
 		// Bail if no meta table exists
-		if ( empty( $table ) ) {
+		if ( false === $this->get_meta_table_name() ) {
 			return false;
 		}
 
-		// Return results of get meta data
-		return delete_metadata( $table, $item_id, $meta_key, $meta_value, $delete_all );
+		// Get meta type
+		$meta_type = $this->get_meta_type();
+
+		// Return results of deleting meta data
+		return delete_metadata( $meta_type, $item_id, $meta_key, $meta_value, $delete_all );
 	}
 
 	/**
@@ -2314,7 +2322,7 @@ class Query extends Base {
 	private function get_registered_meta_keys( $object_subtype = '' ) {
 
 		// Get the object type
-		$object_type = $this->apply_prefix( $this->item_name );
+		$object_type = $this->get_meta_type();
 
 		// Return the keys
 		return get_registered_meta_keys( $object_type, $object_subtype );
@@ -2335,11 +2343,8 @@ class Query extends Base {
 			return;
 		}
 
-		// Get meta table name
-		$table = $this->get_meta_table_name();
-
 		// Bail if no meta table exists
-		if ( empty( $table ) ) {
+		if ( false === $this->get_meta_table_name() ) {
 			return;
 		}
 
@@ -2375,7 +2380,7 @@ class Query extends Base {
 			return;
 		}
 
-		// Get meta table name
+		// Get the meta table name
 		$table = $this->get_meta_table_name();
 
 		// Bail if no meta table exists
@@ -2388,8 +2393,8 @@ class Query extends Base {
 		$item_id_column = $this->apply_prefix( "{$this->item_name}_{$primary_id}" );
 
 		// Get meta IDs
-		$sql      = "SELECT meta_id FROM {$table} WHERE {$item_id_column} = %d";
-		$prepared = $this->get_db()->prepare( $sql, $item_id );
+		$query    = "SELECT meta_id FROM {$table} WHERE {$item_id_column} = %d";
+		$prepared = $this->get_db()->prepare( $query, $item_id );
 		$meta_ids = $this->get_db()->get_col( $prepared );
 
 		// Bail if no meta IDs to delete
@@ -2397,8 +2402,8 @@ class Query extends Base {
 			return;
 		}
 
-		// Maybe apply the prefix to the meta type.
-		$meta_type = $this->apply_prefix( $this->item_name );
+		// Get the meta type
+		$meta_type = $this->get_meta_type();
 
 		// Delete all meta data for this item ID
 		foreach ( $meta_ids as $mid ) {
@@ -2407,7 +2412,10 @@ class Query extends Base {
 	}
 
 	/**
-	 * Return meta table
+	 * Get the meta table for this query
+	 *
+	 * Forked from WordPress\_get_meta_table() so it can be more accurately
+	 * predicted in a future iteration and default to returning false.
 	 *
 	 * @since 1.0.0
 	 *
@@ -2415,11 +2423,36 @@ class Query extends Base {
 	 */
 	private function get_meta_table_name() {
 
-		// Maybe apply table prefix
-		$table = $this->apply_prefix( $this->item_name );
+		// Get the meta-type
+		$type = $this->get_meta_type();
 
-		// Return table if exists, or false if not
-		return _get_meta_table( $table );
+		// Append "meta" to end of meta-type
+		$table_name = "{$type}meta";
+
+		// Variable'ize the database interface, to use inside empty()
+		$db = $this->get_db();
+
+		// If not empty, return table name
+		if ( ! empty( $db->{$table_name} ) ) {
+			return $db->{$table_name};
+		}
+
+		// Default return false
+		return false;
+	}
+
+	/**
+	 * Get the meta type for this query
+	 *
+	 * This method exists to reduce some duplication for now. Future iterations
+	 * will likely use Column::relationships to
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string
+	 */
+	private function get_meta_type() {
+		return $this->apply_prefix( $this->item_name );
 	}
 
 	/** Cache *****************************************************************/

--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -294,7 +294,14 @@ function edd_destroy_order( $order_id = 0 ) {
 		}
 	}
 
-
+	/**
+	 * Action hook for developers to do extra work when an order is destroyed.
+	 *
+	 * @since 3.0
+	 * @param int  $order_id  The original order ID.
+	 * @param bool $destroyed Whether the order was destroyed.
+	 */
+	do_action( 'edd_order_destroyed', $order_id, $destroyed );
 
 	return $destroyed;
 }

--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -242,6 +242,14 @@ function edd_delete_order( $order_id = 0 ) {
  */
 function edd_destroy_order( $order_id = 0 ) {
 
+	/**
+	 * Action hook for developers to do extra work when an order is destroyed.
+	 *
+	 * @since 3.0
+	 * @param int  $order_id  The original order ID.
+	 */
+	do_action( 'edd_pre_destroy_order', $order_id );
+
 	// Delete the order
 	$destroyed = edd_delete_order( $order_id );
 

--- a/tests/orders/tests-orders.php
+++ b/tests/orders/tests-orders.php
@@ -76,11 +76,25 @@ class Orders_Tests extends \EDD_UnitTestCase {
 	public function test_delete_should_delete_metadata() {
 		edd_add_order_meta( self::$orders[1], 'test_meta_key', 'test_meta_value', true );
 
-		// This assertion is added to ensure that metada was, in fact, added to the order.
-		$this->assertEquals( edd_get_order_meta( self::$orders[1], 'test_meta_key', true ), 'test_meta_value' );
+		// This assertion is added to ensure that metadata was, in fact, added to the order.
+		$this->assertEquals( 'test_meta_value', edd_get_order_meta( self::$orders[1], 'test_meta_key', true ) );
 
 		edd_delete_order( self::$orders[1] );
 		$this->assertEmpty( edd_get_order_meta( self::$orders[1], 'test_meta_key', true ) );
+	}
+
+	/**
+	 * @covers ::edd_delete_order
+	 */
+	public function test_delete_should_delete_metadata_non_unique() {
+		edd_add_order_meta( self::$orders[1], 'test_meta_key', '2', false );
+		edd_add_order_meta( self::$orders[1], 'test_meta_key', '1', false );
+
+		// This assertion is added to ensure that metadata was, in fact, added to the order.
+		$this->assertEquals( array( 2, 1 ), edd_get_order_meta( self::$orders[1], 'test_meta_key', false ) );
+
+		edd_delete_order( self::$orders[1] );
+		$this->assertEmpty( edd_get_order_meta( self::$orders[1], 'test_meta_key', false ) );
 	}
 
 	/**

--- a/tests/orders/tests-orders.php
+++ b/tests/orders/tests-orders.php
@@ -73,6 +73,19 @@ class Orders_Tests extends \EDD_UnitTestCase {
 	/**
 	 * @covers ::edd_delete_order
 	 */
+	public function test_delete_should_delete_metadata() {
+		edd_add_order_meta( self::$orders[1], 'test_meta_key', 'test_meta_value', true );
+
+		// This assertion is added to ensure that metada was, in fact, added to the order.
+		$this->assertEquals( edd_get_order_meta( self::$orders[1], 'test_meta_key', true ), 'test_meta_value' );
+
+		edd_delete_order( self::$orders[1] );
+		$this->assertEmpty( edd_get_order_meta( self::$orders[1], 'test_meta_key', true ) );
+	}
+
+	/**
+	 * @covers ::edd_delete_order
+	 */
 	public function test_delete_without_id_should_fail() {
 		$success = edd_delete_order( '' );
 


### PR DESCRIPTION
Fixes #9138

Proposed Changes:
1. Runs the meta type parameter through `add_prefix` before attempting to delete the metadata.
2. Adds a unit test to ensure that order meta is deleted when an order is deleted.
3. Adds `edd_order_destroyed` action hook.

Note: this is already fixed in BerlinDB (https://github.com/berlindb/core/issues/84) and I'm thinking EDD is on version 1.0.x of Berlin. This PR is pretty minimal--and actually looking at what was done to resolve the issue in Berlin, probably incomplete.
