### PR TITLE
Reset date string if invalid

### DIFF
--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -85,29 +85,16 @@ function edd_update_payment_details( $data = array() ) {
 
 	$order_update_args = array();
 
-	$unlimited  = isset( $data['edd-unlimited-downloads'] ) ? '1' : null;
-	$new_status = sanitize_key( $data['edd-payment-status'] );
-	$date       = sanitize_text_field( $data['edd-payment-date'] );
-	$hour       = sanitize_text_field( $data['edd-payment-time-hour'] );
-
-	// Restrict to our high and low
-	if ( $hour > 23 ) {
-		$hour = 23;
-	} elseif ( $hour < 0 ) {
-		$hour = 00;
-	}
-
-	$minute = sanitize_text_field( $data['edd-payment-time-min'] );
-
-	// Restrict to our high and low
-	if ( $minute > 59 ) {
-		$minute = 59;
-	} elseif ( $minute < 0 ) {
-		$minute = 00;
-	}
+	$unlimited   = isset( $data['edd-unlimited-downloads'] ) ? '1' : null;
+	$new_status  = sanitize_key( $data['edd-payment-status'] );
+	$date_string = edd_get_date_string(
+		sanitize_text_field( $order_data['edd-payment-date'] ),
+		sanitize_text_field( $order_data['edd-payment-time-hour'] ),
+		sanitize_text_field( $order_data['edd-payment-time-min'] )
+	);
 
 	// The date is entered in the WP timezone. We need to convert it to UTC prior to saving now.
-	$date = edd_get_utc_equivalent_date( EDD()->utils->date( $date . ' ' . $hour . ':' . $minute . ':00', edd_get_timezone_id(), false ) );
+	$date = edd_get_utc_equivalent_date( EDD()->utils->date( $date_string, edd_get_timezone_id(), false ) );
 	$date = $date->format( 'Y-m-d H:i:s' );
 
 	$order_update_args['date_created'] = $date;

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -87,7 +87,7 @@ function edd_update_payment_details( $data = array() ) {
 
 	$unlimited   = isset( $data['edd-unlimited-downloads'] ) ? '1' : null;
 	$new_status  = sanitize_key( $data['edd-payment-status'] );
-	$date_string = edd_get_date_string(
+	$date_string = EDD()->utils->get_date_string(
 		sanitize_text_field( $order_data['edd-payment-date'] ),
 		sanitize_text_field( $order_data['edd-payment-time-hour'] ),
 		sanitize_text_field( $order_data['edd-payment-time-min'] )

--- a/includes/class-utilities.php
+++ b/includes/class-utilities.php
@@ -229,6 +229,11 @@ class Utilities {
 			$timezone = 'UTC';
 		}
 
+		// If the date string cannot be property converted to a valid time, reset it to now.
+		if ( ! strtotime( $date_string ) ) {
+			$date_string = 'now';
+		}
+
 		/*
 		 * Create the DateTime object with the "local" WordPress timezone.
 		 *

--- a/includes/class-utilities.php
+++ b/includes/class-utilities.php
@@ -324,6 +324,35 @@ class Utilities {
 		return $this->time_zone;
 	}
 
+	/**
+	 * Gets a valid date string in the format Y-m-d HH:MM:00
+	 *
+	 * @since 3.0
+	 * @param string $date   A valid date string.
+	 * @param int    $hour   The hour.
+	 * @param int    $minute The minute.
+	 * @return string
+	 */
+	public function get_date_string( $date = '', $hour = 0, $minute = 0 ) {
+		if ( empty( $date ) || ! strtotime( $date ) ) {
+			$date = date( 'Y-m-d' );
+		}
+
+		$hour = absint( $hour );
+		if ( $hour > 23 ) {
+			$hour = 23;
+		}
+		$hour = str_pad( $hour, 2, '0', STR_PAD_LEFT );
+
+		$minute = absint( $minute );
+		if ( $minute > 59 ) {
+			$minute = 59;
+		}
+		$minute = str_pad( $minute, 2, '0', STR_PAD_LEFT );
+
+		return "{$date} {$hour}:{$minute}:00";
+	}
+
 	/** Private Setters *******************************************************/
 
 	/**

--- a/includes/date-functions.php
+++ b/includes/date-functions.php
@@ -283,32 +283,3 @@ function edd_get_minute_values() {
 		'59' => '59'
 	) );
 }
-
-/**
- * Gets a valid date string in the format Y-m-d HH:MM:00
- *
- * @since 3.0
- * @param string $date   A valid date string.
- * @param int    $hour   The hour.
- * @param int    $minute The minute.
- * @return string
- */
-function edd_get_date_string( $date = '', $hour = 0, $minute = 0 ) {
-	if ( empty( $date ) || ! strtotime( $date ) ) {
-		$date = date( 'Y-m-d' );
-	}
-
-	$hour = absint( $hour );
-	if ( $hour > 23 ) {
-		$hour = 23;
-	}
-	$hour = str_pad( $hour, 2, '0', STR_PAD_LEFT );
-
-	$minute = absint( $minute );
-	if ( $minute > 59 ) {
-		$minute = 59;
-	}
-	$minute = str_pad( $minute, 2, '0', STR_PAD_LEFT );
-
-	return "{$date} {$hour}:{$minute}:00";
-}

--- a/includes/date-functions.php
+++ b/includes/date-functions.php
@@ -283,3 +283,32 @@ function edd_get_minute_values() {
 		'59' => '59'
 	) );
 }
+
+/**
+ * Gets a valid date string in the format Y-m-d HH:MM:00
+ *
+ * @since 3.0
+ * @param string $date   A valid date string.
+ * @param int    $hour   The hour.
+ * @param int    $minute The minute.
+ * @return string
+ */
+function edd_get_date_string( $date = '', $hour = 0, $minute = 0 ) {
+	if ( empty( $date ) || ! strtotime( $date ) ) {
+		$date = date( 'Y-m-d' );
+	}
+
+	$hour = absint( $hour );
+	if ( $hour > 23 ) {
+		$hour = 23;
+	}
+	$hour = str_pad( $hour, 2, '0', STR_PAD_LEFT );
+
+	$minute = absint( $minute );
+	if ( $minute > 59 ) {
+		$minute = 59;
+	}
+	$minute = str_pad( $minute, 2, '0', STR_PAD_LEFT );
+
+	return "{$date} {$hour}:{$minute}:00";
+}

--- a/includes/orders/functions/actions.php
+++ b/includes/orders/functions/actions.php
@@ -119,28 +119,15 @@ function edd_add_manual_order( $args = array() ) {
 		$status = 'complete';
 	}
 
-	// Parse date.
-	$date = sanitize_text_field( $order_data['edd-payment-date'] );
-	$hour = sanitize_text_field( $order_data['edd-payment-time-hour'] );
-
-	// Restrict to our high and low.
-	if ( $hour > 23 ) {
-		$hour = 23;
-	} elseif ( $hour < 0 ) {
-		$hour = 00;
-	}
-
-	$minute = sanitize_text_field( $order_data['edd-payment-time-min'] );
-
-	// Restrict to our high and low.
-	if ( $minute > 59 ) {
-		$minute = 59;
-	} elseif ( $minute < 0 ) {
-		$minute = 00;
-	}
+	// Get the date string.
+	$date_string = edd_get_date_string(
+		sanitize_text_field( $order_data['edd-payment-date'] ),
+		sanitize_text_field( $order_data['edd-payment-time-hour'] ),
+		sanitize_text_field( $order_data['edd-payment-time-min'] )
+	);
 
 	// The date is entered in the WP timezone. We need to convert it to UTC prior to saving now.
-	$date = edd_get_utc_equivalent_date( EDD()->utils->date( $date . ' ' . $hour . ':' . $minute . ':00', edd_get_timezone_id(), false ) );
+	$date = edd_get_utc_equivalent_date( EDD()->utils->date( $date_string, edd_get_timezone_id(), false ) );
 	$date = $date->format( 'Y-m-d H:i:s' );
 
 	// Get mode

--- a/includes/orders/functions/actions.php
+++ b/includes/orders/functions/actions.php
@@ -120,7 +120,7 @@ function edd_add_manual_order( $args = array() ) {
 	}
 
 	// Get the date string.
-	$date_string = edd_get_date_string(
+	$date_string = EDD()->utils->get_date_string(
 		sanitize_text_field( $order_data['edd-payment-date'] ),
 		sanitize_text_field( $order_data['edd-payment-time-hour'] ),
 		sanitize_text_field( $order_data['edd-payment-time-min'] )

--- a/tests/tests-date-functions.php
+++ b/tests/tests-date-functions.php
@@ -62,16 +62,6 @@ class Date_Functions_Tests extends EDD_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::EDD()->utils->date()
-	 *
-	 */
-	public function test_date_invalid_date_returns_date() {
-		$date = EDD()->utils->date( '::00', edd_get_timezone_id(), false );
-
-		$this->assertTrue( $date instanceof EDD\Utils\Date );
-	}
-
-	/**
 	 * @covers ::edd_get_timezone_id()
 	 */
 	public function test_get_timezone_should_return_the_current_timezone_based_on_WP_settings() {
@@ -258,5 +248,44 @@ class Date_Functions_Tests extends EDD_UnitTestCase {
 		$this->assertEquals( 1, $dates['day_end'] );
 		$this->assertEquals( date( 'n', strtotime( '+1 month' ) ), $dates['m_end'] );
 		$this->assertEquals( date( 'Y', strtotime( '+1 month' ) ), $dates['year_end'] );
+	}
+
+	/**
+	 * @covers ::EDD()->utils->date()
+	 *
+	 */
+	public function test_date_invalid_date_returns_date() {
+		$date = EDD()->utils->date( '::00', edd_get_timezone_id(), false );
+
+		$this->assertTrue( $date instanceof EDD\Utils\Date );
+	}
+
+	/**
+	 * @covers ::edd_get_date_string()
+	 */
+	public function test_get_date_string_valid_returns_valid_string() {
+		$actual = edd_get_date_string( '2020-01-10', 13, 9 );
+
+		$this->assertSame( '2020-01-10 13:09:00', $actual );
+	}
+
+	/**
+	 * @covers ::edd_get_date_string()
+	 */
+	public function test_get_date_string_empty_returns_valid_string() {
+		$actual   = edd_get_date_string();
+		$expected = date( 'Y-m-d' ) . ' 00:00:00';
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * @covers ::edd_get_date_string()
+	 */
+	public function test_get_date_string_invalid_returns_valid_string() {
+		$actual   = edd_get_date_string( '2020-01-100', 100, 99 );
+		$expected = date( 'Y-m-d' ) . ' 23:59:00';
+
+		$this->assertContains( $expected, $actual );
 	}
 }

--- a/tests/tests-date-functions.php
+++ b/tests/tests-date-functions.php
@@ -62,6 +62,16 @@ class Date_Functions_Tests extends EDD_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::EDD()->utils->date()
+	 *
+	 */
+	public function test_date_invalid_date_returns_date() {
+		$date = EDD()->utils->date( '::00', edd_get_timezone_id(), false );
+
+		$this->assertTrue( $date instanceof EDD\Utils\Date );
+	}
+
+	/**
 	 * @covers ::edd_get_timezone_id()
 	 */
 	public function test_get_timezone_should_return_the_current_timezone_based_on_WP_settings() {

--- a/tests/tests-date-functions.php
+++ b/tests/tests-date-functions.php
@@ -261,29 +261,29 @@ class Date_Functions_Tests extends EDD_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::edd_get_date_string()
+	 * @covers ::EDD()->utils->get_date_string()
 	 */
 	public function test_get_date_string_valid_returns_valid_string() {
-		$actual = edd_get_date_string( '2020-01-10', 13, 9 );
+		$actual = EDD()->utils->get_date_string( '2020-01-10', 13, 9 );
 
 		$this->assertSame( '2020-01-10 13:09:00', $actual );
 	}
 
 	/**
-	 * @covers ::edd_get_date_string()
+	 * @covers ::EDD()->utils->get_date_string()
 	 */
 	public function test_get_date_string_empty_returns_valid_string() {
-		$actual   = edd_get_date_string();
+		$actual   = EDD()->utils->get_date_string();
 		$expected = date( 'Y-m-d' ) . ' 00:00:00';
 
 		$this->assertSame( $expected, $actual );
 	}
 
 	/**
-	 * @covers ::edd_get_date_string()
+	 * @covers ::EDD()->utils->get_date_string()
 	 */
 	public function test_get_date_string_invalid_returns_valid_string() {
-		$actual   = edd_get_date_string( '2020-01-100', 100, 99 );
+		$actual   = EDD()->utils->get_date_string( '2020-01-100', 100, 99 );
 		$expected = date( 'Y-m-d' ) . ' 23:59:00';
 
 		$this->assertContains( $expected, $actual );


### PR DESCRIPTION
Fixes #9150

Proposed Changes:
1. In `EDD()->utils->date`, adds a check for whether the incoming string is a valid date/time string. If not, resets it to `'now'`.
2. Adds a unit test which tests an invalid date string to ensure it returns a valid date object.