### PR TITLE
Fix SQL sytnax error.

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1640,7 +1640,7 @@ function edd_hide_payment_notes_pre_41( $clauses, $wp_comment_query ) {
 	global $wpdb, $wp_version;
 
 	if( version_compare( floatval( $wp_version ), '4.1', '<' ) ) {
-		$clauses['where'] .= ' AND comment_type != "edd_payment_note"';
+		$clauses['where'] .= " AND comment_type != 'edd_payment_note'";
 	}
 
 	return $clauses;


### PR DESCRIPTION
Fixes MySQL syntax error. Error:
```
SELECT comment_approved, COUNT( * ) AS num_comments FROM wp_comments WHERE comment_type != "edd_payment_note" GROUP BY comment_approved
Unknown column 'edd_payment_note' in 'where clause'
```

Proposed Changes:
1. Switch double quoted WHERE clause value to single quoted
