### PR TITLE
Update products CLI product ID

### DIFF
--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -135,7 +135,11 @@ class EDD_CLI extends WP_CLI_Command {
 	 */
 	public function products( $args, $assoc_args ) {
 		$product_id = isset( $assoc_args ) && array_key_exists( 'id', $assoc_args ) ? absint( $assoc_args['id'] ) : false;
-		$products   = $this->api->get_products( $product_id );
+		if ( $product_id ) {
+			$products = $this->api->get_products( array( 'product' => $product_id ) );
+		} else {
+			$products = $this->api->get_products();
+		}
 
 		if ( isset( $products['error'] ) ) {
 			WP_CLI::error( $products['error'] );


### PR DESCRIPTION
Fixes #9146

Proposed Changes:
1. Updates `$this->api->get_products()` usage to query by product ID only if one is set.
2. Additionally, makes sure the product ID parameter is properly formatted.
