### PR TITLE
Show download links for partially refunded order items in download history

### DIFF
--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -74,7 +74,7 @@ if ( $orders ) :
 						<td class="edd_download_download_files">
 							<?php
 
-							if ( 'complete' == $item->status ) :
+							if ( in_array( $item->status, array( 'complete', 'partially_refunded' ), true ) ) :
 
 								if ( $download_files ) :
 


### PR DESCRIPTION
Fixes #9172

Proposed Changes:
1. Updates the logic for showing download files to include `partially_refunded` as well as `complete`.