### PR TITLE
Create order item is_deliverable method

### DIFF
--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -632,7 +632,7 @@ function edd_order_details_overview( $order ) {
 				'dateCreated'  => esc_html( $item->date_created ),
 				'dateModified' => esc_html( $item->date_modified ),
 				'uuid'         => esc_html( $item->uuid ),
-
+				'deliverable'  => $item->is_deliverable(),
 				'adjustments'  => $item_adjustments,
 			);
 		}

--- a/includes/admin/views/tmpl-order-item.php
+++ b/includes/admin/views/tmpl-order-item.php
@@ -48,7 +48,7 @@ $view_url = add_query_arg(
 				</span>
 				<# } #>
 
-				<# if ( false === data.state.isAdding && 'complete' === data.status ) { #>
+				<# if ( false === data.state.isAdding && true === data.deliverable ) { #>
 				<span>
 					<button class="button-link copy-download-link">
 						<?php echo esc_html( sprintf( __( 'Copy %s Links', 'easy-digital-downloads' ), edd_get_label_singular() ) ); ?>

--- a/includes/class-edd-download.php
+++ b/includes/class-edd-download.php
@@ -556,7 +556,7 @@ class EDD_Download {
 	 * @return array List of bundled downloads
 	 */
 	public function get_variable_priced_bundled_downloads( $price_id = null ) {
-		if ( null == $price_id ) {
+		if ( null === $price_id ) {
 			return $this->get_bundled_downloads();
 		}
 

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1269,7 +1269,12 @@ function edd_get_download_file_url( $key, $email, $filekey, $download_id = 0, $p
 	$args = array_fill_keys( edd_get_url_token_parameters(), '' );
 
 	// Simply the URL by concatenating required data using a colon as a delimiter.
-	$args['eddfile'] = rawurlencode( sprintf( '%d:%d:%d:%d', $order->id, $params['download_id'], $params['file'], $price_id ) );
+	if ( ! is_numeric( $price_id ) ) {
+		$eddfile = sprintf( '%d:%d:%d', $order->id, $params['download_id'], $params['file'] );
+	} else {
+		$eddfile = sprintf( '%d:%d:%d:%d', $order->id, $params['download_id'], $params['file'], $price_id );
+	}
+	$args['eddfile'] = rawurlencode( $eddfile );
 
 	if ( isset( $params['expire'] ) ) {
 		$args['ttl'] = $params['expire'];

--- a/includes/emails/tags.php
+++ b/includes/emails/tags.php
@@ -288,7 +288,6 @@ function edd_email_tag_download_list( $payment_id ) {
 		return '';
 	}
 
-	$payment_data  = $payment->get_meta();
 	$download_list = '<ul>';
 	$cart_items    = $payment->cart_details;
 	$email         = $payment->email;
@@ -331,12 +330,12 @@ function edd_email_tag_download_list( $payment_id ) {
 
 					if ( $show_links ) {
 						$download_list .= '<div>';
-							$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $item->product_id, $item->price_id );
-							$download_list .= '<a href="' . esc_url_raw( $file_url ) . '">' . edd_get_file_name( $file ) . '</a>';
-							$download_list .= '</div>';
+						$file_url       = edd_get_download_file_url( $order->payment_key, $email, $filekey, $item->product_id, $item->price_id );
+						$download_list .= '<a href="' . esc_url_raw( $file_url ) . '">' . edd_get_file_name( $file ) . '</a>';
+						$download_list .= '</div>';
 					} else {
 						$download_list .= '<div>';
-							$download_list .= edd_get_file_name( $file );
+						$download_list .= edd_get_file_name( $file );
 						$download_list .= '</div>';
 					}
 
@@ -350,12 +349,14 @@ function edd_email_tag_download_list( $payment_id ) {
 
 					$download_list .= '<div class="edd_bundled_product"><strong>' . get_the_title( $bundle_item ) . '</strong></div>';
 
-					$download_files = edd_get_download_files( edd_get_bundle_item_id( $bundle_item ), edd_get_bundle_item_price_id( $bundle_item ) );
+					$bundle_item_id       = edd_get_bundle_item_id( $bundle_item );
+					$bundle_item_price_id = edd_get_bundle_item_price_id( $bundle_item );
+					$download_files       = edd_get_download_files( $bundle_item_id, $bundle_item_price_id );
 
 					foreach ( $download_files as $filekey => $file ) {
 						if ( $show_links ) {
 							$download_list .= '<div>';
-							$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $bundle_item, $item->price_id );
+							$file_url       = edd_get_download_file_url( $order->payment_key, $email, $filekey, $bundle_item_id, $bundle_item_price_id );
 							$download_list .= '<a href="' . esc_url( $file_url ) . '">' . edd_get_file_name( $file ) . '</a>';
 							$download_list .= '</div>';
 						} else {

--- a/includes/orders/classes/class-order-item.php
+++ b/includes/orders/classes/class-order-item.php
@@ -259,6 +259,6 @@ class Order_Item extends \EDD\Database\Rows\Order_Item {
 	 * @return bool
 	 */
 	public function is_deliverable() {
-		return in_array( $this->status, array( 'complete', 'partially_refunded' ), true );
+		return in_array( $this->status, edd_get_deliverable_order_item_statuses(), true );
 	}
 }

--- a/includes/orders/classes/class-order-item.php
+++ b/includes/orders/classes/class-order-item.php
@@ -251,4 +251,14 @@ class Order_Item extends \EDD\Database\Rows\Order_Item {
 			'parent' => $this->id
 		) );
 	}
+
+	/**
+	 * Checks the order item status to determine whether assets can be delivered.
+	 *
+	 * @since 3.0
+	 * @return bool
+	 */
+	public function is_deliverable() {
+		return in_array( $this->status, array( 'complete', 'partially_refunded' ), true );
+	}
 }

--- a/includes/orders/functions/statuses.php
+++ b/includes/orders/functions/statuses.php
@@ -153,3 +153,22 @@ function edd_get_refundable_order_statuses() {
 	 */
 	return (array) apply_filters( 'edd_refundable_order_statuses', $refundable_order_statuses );
 }
+
+/**
+ * Returns an array of order item statuses that allow assets to be delivvered.
+ *
+ * @since 3.0
+ * @return array
+ */
+function edd_get_deliverable_order_item_statuses() {
+	$deliverable_order_item_statuses = array( 'complete', 'partially_refunded' );
+
+	/**
+	 * Filters the order item statuses that aallow assets to be delivered.
+	 *
+	 * @param array $refundable_order_statuses
+	 *
+	 * @since 3.0
+	 */
+	return (array) apply_filters( 'edd_deliverable_order_item_statuses', $deliverable_order_item_statuses );
+}

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -867,25 +867,27 @@ function edd_process_signed_download_url( $args ) {
 	}
 
 	$order_parts = explode( ':', rawurldecode( $_GET['eddfile'] ) );
+	$price_id    = isset( $order_parts[3] ) ? (int) $order_parts[3] : null;
 
 	// Check to make sure not at download limit
-	if ( edd_is_file_at_download_limit( $order_parts[1], $order_parts[0], $order_parts[2], $order_parts[3] ) ) {
+	if ( edd_is_file_at_download_limit( $order_parts[1], $order_parts[0], $order_parts[2], $price_id ) ) {
 		wp_die( apply_filters( 'edd_download_limit_reached_text', __( 'Sorry but you have hit your download limit for this file.', 'easy-digital-downloads' ) ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 	}
 
-	$args['expire']      = $_GET['ttl'];
-	$args['download']    = $order_parts[1];
-	$args['payment']     = $order_parts[0];
-	$args['file_key']    = $order_parts[2];
-	$args['price_id']    = $order_parts[3];
-	$args['email']       = edd_get_payment_meta( $order_parts[0], '_edd_payment_user_email', true );
-	$args['key']         = edd_get_payment_meta( $order_parts[0], '_edd_payment_purchase_key', true );
+	$order            = edd_get_order( $order_parts[0] );
+	$args['expire']   = $_GET['ttl'];
+	$args['download'] = $order_parts[1];
+	$args['payment']  = $order->id;
+	$args['file_key'] = $order_parts[2];
+	$args['price_id'] = $price_id;
+	$args['email']    = $order->email;
+	$args['key']      = $order->payment_key;
 
 	// Access is granted if there's at least one `complete` order item that matches the order + download + price ID.
 	$args['has_access'] = edd_order_grants_access_to_download_files( array(
-		'order_id'   => $args['payment'],
+		'order_id'   => $order->id,
 		'product_id' => $args['download'],
-		'price_id'   => ! empty( $args['price_id'] ) ? $args['price_id'] : ''
+		'price_id'   => $args['price_id'],
 	) );
 
 	return $args;
@@ -893,7 +895,7 @@ function edd_process_signed_download_url( $args ) {
 
 /**
  * Determines whether or not a given order grants access to download files associated with a given
- * product ID and price ID combination. Returns true if there's at least one `complete` order item
+ * product ID and price ID combination. Returns true if there's at least one deliverable order item
  * matching the requirements.
  *
  * @param array $args
@@ -905,7 +907,7 @@ function edd_order_grants_access_to_download_files( $args ) {
 	$args = wp_parse_args( $args, array(
 		'order_id'   => 0,
 		'product_id' => 0,
-		'price_id'   => ''
+		'price_id'   => null,
 	) );
 
 	// Order and product IDs are required.
@@ -913,16 +915,45 @@ function edd_order_grants_access_to_download_files( $args ) {
 		return false;
 	}
 
-	$args = array(
-		'order_id'   => $args['order_id'],
-		'product_id' => $args['product_id'],
-		'price_id'   => $args['price_id'],
-		'status'     => edd_get_deliverable_order_item_statuses(),
+	$args['status'] = edd_get_deliverable_order_item_statuses();
+	if ( is_null( $args['price_id'] ) ) {
+		unset( $args['price_id'] );
+	}
+
+	// Check if the download was purchased directly.
+	$order_items = edd_count_order_items( $args );
+
+	if ( $order_items > 0 ) {
+		return true;
+	}
+
+	$order_items = edd_get_order_items(
+		array(
+			'order_id' => $args['order_id'],
+			'status'   => edd_get_deliverable_order_item_statuses(),
+			'fields'   => 'product_id',
+		)
 	);
 
-	$order_items = edd_count_order_items( array_filter( $args ) );
+	// Unlikely, but return false if there are no order items found at all.
+	if ( empty( $order_items ) ) {
+		return false;
+	}
 
-	return $order_items > 0;
+	// Check if the requested download is part of a bundle.
+	$product_to_check = isset( $args['price_id'] ) && is_numeric( $args['price_id'] ) ? "{$args['product_id']}_{$args['price_id']}" : $args['product_id'];
+	foreach ( $order_items as $product_id ) {
+		$download = edd_get_download( $product_id );
+		if ( ! $download instanceof EDD_Download || 'bundle' !== $download->type ) {
+			continue;
+		}
+
+		if ( in_array( $product_to_check, $download->get_bundled_downloads() ) ) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 /**

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -917,7 +917,7 @@ function edd_order_grants_access_to_download_files( $args ) {
 		'order_id'   => $args['order_id'],
 		'product_id' => $args['product_id'],
 		'price_id'   => $args['price_id'],
-		'status'     => 'complete'
+		'status'     => edd_get_deliverable_order_item_statuses(),
 	);
 
 	$order_items = edd_count_order_items( array_filter( $args ) );

--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -74,7 +74,7 @@ if ( $orders ) :
 						<td class="edd_download_download_files">
 							<?php
 
-							if ( in_array( $item->status, array( 'complete', 'partially_refunded' ), true ) ) :
+							if ( $item->is_deliverable() ) :
 
 								if ( $download_files ) :
 

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -270,13 +270,15 @@ if ( empty( $order_items ) ) {
 									<span class="edd_bundled_product_name"><?php echo esc_html( edd_get_bundle_item_title( $bundle_item ) ); ?></span>
 									<ul class="edd_bundled_product_files">
 										<?php
-										$download_files = edd_get_download_files( edd_get_bundle_item_id( $bundle_item ), edd_get_bundle_item_price_id( $bundle_item ) );
+										$bundle_item_id       = edd_get_bundle_item_id( $bundle_item );
+										$bundle_item_price_id = edd_get_bundle_item_price_id( $bundle_item );
+										$download_files       = edd_get_download_files( $bundle_item_id, $bundle_item_price_id );
 
 										if ( $download_files && is_array( $download_files ) ) :
 											foreach ( $download_files as $filekey => $file ) :
 												?>
 												<li class="edd_download_file">
-													<a href="<?php echo esc_url( edd_get_download_file_url( $order->payment_key, $order->email, $filekey, $bundle_item, $item->price_id ) ); ?>" class="edd_download_file_link"><?php echo esc_html( edd_get_file_name( $file ) ); ?></a>
+													<a href="<?php echo esc_url( edd_get_download_file_url( $order->payment_key, $order->email, $filekey, $bundle_item, $bundle_item_price_id ) ); ?>" class="edd_download_file_link"><?php echo esc_html( edd_get_file_name( $file ) ); ?></a>
 												</li>
 												<?php
 												/**

--- a/tests/downloads/tests-process-download.php
+++ b/tests/downloads/tests-process-download.php
@@ -39,7 +39,7 @@ class Tests_Process_Download extends EDD_UnitTestCase {
 			'order_id'     => $order_id,
 			'product_id'   => 1,
 			'product_name' => 'Simple Download',
-			'price_id'     => 1,
+			'price_id'     => 0,
 			'status'       => 'complete',
 			'amount'       => 10,
 			'subtotal'     => 10,
@@ -100,7 +100,16 @@ class Tests_Process_Download extends EDD_UnitTestCase {
 		$this->assertTrue( edd_order_grants_access_to_download_files( array(
 			'order_id'   => self::$order->id,
 			'product_id' => 1,
-			'price_id'   => 1
+			'price_id'   => 0,
+		) ) );
+	}
+
+	public function test_order_with_null_price_id_should_return_true() {
+		// Not specifying price ID
+		$this->assertTrue( edd_order_grants_access_to_download_files( array(
+			'order_id'   => self::$order->id,
+			'product_id' => 2,
+			'price_id'   => null,
 		) ) );
 	}
 
@@ -201,6 +210,30 @@ class Tests_Process_Download extends EDD_UnitTestCase {
 			'order_id'   => $order_id,
 			'product_id' => 1
 		) ) );
+	}
+
+	/**
+	 * @covers edd_order_grants_access_to_download_files
+	 */
+	public function test_bundled_download_should_be_deliverable() {
+		$bundled_product    = EDD_Helper_Download::create_bundled_download();
+		$bundled_order_item = edd_add_order_item(
+			array(
+				'order_id'   => self::$order->id,
+				'product_id' => $bundled_product->ID,
+				'subtotal'   => 9.99,
+				'status'     => 'complete',
+			)
+		);
+
+		$this->assertTrue(
+			edd_order_grants_access_to_download_files(
+				array(
+					'order_id'   => self::$order->id,
+					'product_id' => $bundled_product->ID,
+				)
+			)
+		);
 	}
 
 	public function test_file_download_token() {

--- a/tests/orders/tests-order-items.php
+++ b/tests/orders/tests-order-items.php
@@ -839,4 +839,11 @@ class Order_Item_Tests extends \EDD_UnitTestCase {
 
 		$this->assertFalse( $order_item->is_deliverable() );
 	}
+
+	/**
+	 * @covers edd_get_deliverable_order_item_statuses
+	 */
+	public function test_order_item_deliverable_statuses_includes_partially_refunded() {
+		$this->assertTrue( in_array( 'partially_refunded', edd_get_deliverable_order_item_statuses(), true ) );
+	}
 }

--- a/tests/orders/tests-order-items.php
+++ b/tests/orders/tests-order-items.php
@@ -807,4 +807,36 @@ class Order_Item_Tests extends \EDD_UnitTestCase {
 	public function test_get_fees_should_be_empty() {
 		$this->assertEmpty( edd_get_order_item( self::$order_items[0] )->get_fees() );
 	}
+
+	/**
+	 * @covers ::is_deliverable
+	 */
+	public function test_order_item_marked_complete_is_deliverable_returns_true() {
+		edd_update_order_item(
+			self::$order_items[4],
+			array(
+				'status' => 'complete',
+			)
+		);
+
+		$order_item = edd_get_order_item( self::$order_items[4] );
+
+		$this->assertTrue( $order_item->is_deliverable() );
+	}
+
+	/**
+	 * @covers ::is_deliverable
+	 */
+	public function test_order_item_marked_refunded_is_deliverable_returns_false() {
+		edd_update_order_item(
+			self::$order_items[4],
+			array(
+				'status' => 'refunded',
+			)
+		);
+
+		$order_item = edd_get_order_item( self::$order_items[4] );
+
+		$this->assertFalse( $order_item->is_deliverable() );
+	}
 }


### PR DESCRIPTION
Fixes #9179

Proposed Changes:
1. Creates the `is_deliverable` helper method in the `Order_Item` class. This just determines if assets can be delivered to the customer based on the order item status being `complete` or `partially_refunded`. I'm open to renaming this if needed.
2. Uses the new helper method on the order details screen in the admin and the download history shortcode.