### PR TITLE
Update download file URL, access evaluation

### DIFF
--- a/includes/class-edd-download.php
+++ b/includes/class-edd-download.php
@@ -556,7 +556,7 @@ class EDD_Download {
 	 * @return array List of bundled downloads
 	 */
 	public function get_variable_priced_bundled_downloads( $price_id = null ) {
-		if ( null == $price_id ) {
+		if ( null === $price_id ) {
 			return $this->get_bundled_downloads();
 		}
 

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1269,7 +1269,12 @@ function edd_get_download_file_url( $key, $email, $filekey, $download_id = 0, $p
 	$args = array_fill_keys( edd_get_url_token_parameters(), '' );
 
 	// Simply the URL by concatenating required data using a colon as a delimiter.
-	$args['eddfile'] = rawurlencode( sprintf( '%d:%d:%d:%d', $order->id, $params['download_id'], $params['file'], $price_id ) );
+	if ( ! is_numeric( $price_id ) ) {
+		$eddfile = sprintf( '%d:%d:%d', $order->id, $params['download_id'], $params['file'] );
+	} else {
+		$eddfile = sprintf( '%d:%d:%d:%d', $order->id, $params['download_id'], $params['file'], $price_id );
+	}
+	$args['eddfile'] = rawurlencode( $eddfile );
 
 	if ( isset( $params['expire'] ) ) {
 		$args['ttl'] = $params['expire'];

--- a/includes/emails/tags.php
+++ b/includes/emails/tags.php
@@ -288,7 +288,6 @@ function edd_email_tag_download_list( $payment_id ) {
 		return '';
 	}
 
-	$payment_data  = $payment->get_meta();
 	$download_list = '<ul>';
 	$cart_items    = $payment->cart_details;
 	$email         = $payment->email;
@@ -331,12 +330,12 @@ function edd_email_tag_download_list( $payment_id ) {
 
 					if ( $show_links ) {
 						$download_list .= '<div>';
-							$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $item->product_id, $item->price_id );
-							$download_list .= '<a href="' . esc_url_raw( $file_url ) . '">' . edd_get_file_name( $file ) . '</a>';
-							$download_list .= '</div>';
+						$file_url       = edd_get_download_file_url( $order->payment_key, $email, $filekey, $item->product_id, $item->price_id );
+						$download_list .= '<a href="' . esc_url_raw( $file_url ) . '">' . edd_get_file_name( $file ) . '</a>';
+						$download_list .= '</div>';
 					} else {
 						$download_list .= '<div>';
-							$download_list .= edd_get_file_name( $file );
+						$download_list .= edd_get_file_name( $file );
 						$download_list .= '</div>';
 					}
 
@@ -350,12 +349,14 @@ function edd_email_tag_download_list( $payment_id ) {
 
 					$download_list .= '<div class="edd_bundled_product"><strong>' . get_the_title( $bundle_item ) . '</strong></div>';
 
-					$download_files = edd_get_download_files( edd_get_bundle_item_id( $bundle_item ), edd_get_bundle_item_price_id( $bundle_item ) );
+					$bundle_item_id       = edd_get_bundle_item_id( $bundle_item );
+					$bundle_item_price_id = edd_get_bundle_item_price_id( $bundle_item );
+					$download_files       = edd_get_download_files( $bundle_item_id, $bundle_item_price_id );
 
 					foreach ( $download_files as $filekey => $file ) {
 						if ( $show_links ) {
 							$download_list .= '<div>';
-							$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $bundle_item, $item->price_id );
+							$file_url       = edd_get_download_file_url( $order->payment_key, $email, $filekey, $bundle_item_id, $bundle_item_price_id );
 							$download_list .= '<a href="' . esc_url( $file_url ) . '">' . edd_get_file_name( $file ) . '</a>';
 							$download_list .= '</div>';
 						} else {

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -915,13 +915,13 @@ function edd_order_grants_access_to_download_files( $args ) {
 		return false;
 	}
 
+	$args['status'] = edd_get_deliverable_order_item_statuses();
+	if ( is_null( $args['price_id'] ) ) {
+		unset( $args['price_id'] );
+	}
+
 	// Check if the download was purchased directly.
-	$order_items = edd_count_order_items( array(
-		'order_id'   => $args['order_id'],
-		'product_id' => $args['product_id'],
-		'price_id'   => $args['price_id'],
-		'status'     => edd_get_deliverable_order_item_statuses(),
-	) );
+	$order_items = edd_count_order_items( $args );
 
 	if ( $order_items > 0 ) {
 		return true;
@@ -941,7 +941,7 @@ function edd_order_grants_access_to_download_files( $args ) {
 	}
 
 	// Check if the requested download is part of a bundle.
-	$product_to_check = is_numeric( $args['price_id'] ) ? "{$args['product_id']}_{$args['price_id']}" : $args['product_id'];
+	$product_to_check = isset( $args['price_id'] ) && is_numeric( $args['price_id'] ) ? "{$args['product_id']}_{$args['price_id']}" : $args['product_id'];
 	foreach ( $order_items as $product_id ) {
 		$download = edd_get_download( $product_id );
 		if ( ! $download instanceof EDD_Download || 'bundle' !== $download->type ) {

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -867,9 +867,10 @@ function edd_process_signed_download_url( $args ) {
 	}
 
 	$order_parts = explode( ':', rawurldecode( $_GET['eddfile'] ) );
+	$price_id    = isset( $order_parts[3] ) ? (int) $order_parts[3] : null;
 
 	// Check to make sure not at download limit
-	if ( edd_is_file_at_download_limit( $order_parts[1], $order_parts[0], $order_parts[2], $order_parts[3] ) ) {
+	if ( edd_is_file_at_download_limit( $order_parts[1], $order_parts[0], $order_parts[2], $price_id ) ) {
 		wp_die( apply_filters( 'edd_download_limit_reached_text', __( 'Sorry but you have hit your download limit for this file.', 'easy-digital-downloads' ) ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 	}
 
@@ -878,7 +879,7 @@ function edd_process_signed_download_url( $args ) {
 	$args['download'] = $order_parts[1];
 	$args['payment']  = $order->id;
 	$args['file_key'] = $order_parts[2];
-	$args['price_id'] = $order_parts[3];
+	$args['price_id'] = $price_id;
 	$args['email']    = $order->email;
 	$args['key']      = $order->payment_key;
 
@@ -886,7 +887,7 @@ function edd_process_signed_download_url( $args ) {
 	$args['has_access'] = edd_order_grants_access_to_download_files( array(
 		'order_id'   => $order->id,
 		'product_id' => $args['download'],
-		'price_id'   => ! empty( $args['price_id'] ) ? $args['price_id'] : ''
+		'price_id'   => $args['price_id'],
 	) );
 
 	return $args;

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -270,13 +270,15 @@ if ( empty( $order_items ) ) {
 									<span class="edd_bundled_product_name"><?php echo esc_html( edd_get_bundle_item_title( $bundle_item ) ); ?></span>
 									<ul class="edd_bundled_product_files">
 										<?php
-										$download_files = edd_get_download_files( edd_get_bundle_item_id( $bundle_item ), edd_get_bundle_item_price_id( $bundle_item ) );
+										$bundle_item_id       = edd_get_bundle_item_id( $bundle_item );
+										$bundle_item_price_id = edd_get_bundle_item_price_id( $bundle_item );
+										$download_files       = edd_get_download_files( $bundle_item_id, $bundle_item_price_id );
 
 										if ( $download_files && is_array( $download_files ) ) :
 											foreach ( $download_files as $filekey => $file ) :
 												?>
 												<li class="edd_download_file">
-													<a href="<?php echo esc_url( edd_get_download_file_url( $order->payment_key, $order->email, $filekey, $bundle_item, $item->price_id ) ); ?>" class="edd_download_file_link"><?php echo esc_html( edd_get_file_name( $file ) ); ?></a>
+													<a href="<?php echo esc_url( edd_get_download_file_url( $order->payment_key, $order->email, $filekey, $bundle_item, $bundle_item_price_id ) ); ?>" class="edd_download_file_link"><?php echo esc_html( edd_get_file_name( $file ) ); ?></a>
 												</li>
 												<?php
 												/**

--- a/tests/downloads/tests-process-download.php
+++ b/tests/downloads/tests-process-download.php
@@ -39,7 +39,7 @@ class Tests_Process_Download extends EDD_UnitTestCase {
 			'order_id'     => $order_id,
 			'product_id'   => 1,
 			'product_name' => 'Simple Download',
-			'price_id'     => 1,
+			'price_id'     => 0,
 			'status'       => 'complete',
 			'amount'       => 10,
 			'subtotal'     => 10,
@@ -100,7 +100,7 @@ class Tests_Process_Download extends EDD_UnitTestCase {
 		$this->assertTrue( edd_order_grants_access_to_download_files( array(
 			'order_id'   => self::$order->id,
 			'product_id' => 1,
-			'price_id'   => 1
+			'price_id'   => 0,
 		) ) );
 	}
 

--- a/tests/downloads/tests-process-download.php
+++ b/tests/downloads/tests-process-download.php
@@ -203,6 +203,30 @@ class Tests_Process_Download extends EDD_UnitTestCase {
 		) ) );
 	}
 
+	/**
+	 * @covers edd_order_grants_access_to_download_files
+	 */
+	public function test_bundled_download_should_be_deliverable() {
+		$bundled_product    = EDD_Helper_Download::create_bundled_download();
+		$bundled_order_item = edd_add_order_item(
+			array(
+				'order_id'   => self::$order->id,
+				'product_id' => $bundled_product->ID,
+				'subtotal'   => 9.99,
+				'status'     => 'complete',
+			)
+		);
+
+		$this->assertTrue(
+			edd_order_grants_access_to_download_files(
+				array(
+					'order_id'   => self::$order->id,
+					'product_id' => $bundled_product->ID,
+				)
+			)
+		);
+	}
+
 	public function test_file_download_token() {
 		$eddfile = '1:2:3:4';
 		$ttl     = current_time( 'timestamp' ) + HOUR_IN_SECONDS;

--- a/tests/downloads/tests-process-download.php
+++ b/tests/downloads/tests-process-download.php
@@ -104,6 +104,15 @@ class Tests_Process_Download extends EDD_UnitTestCase {
 		) ) );
 	}
 
+	public function test_order_with_null_price_id_should_return_true() {
+		// Not specifying price ID
+		$this->assertTrue( edd_order_grants_access_to_download_files( array(
+			'order_id'   => self::$order->id,
+			'product_id' => 2,
+			'price_id'   => null,
+		) ) );
+	}
+
 	/**
 	 * If specifying a price ID that was not purchased in this order, files cannot be downloaded
 	 *


### PR DESCRIPTION
Fixes #9182 
Branched from #9179 due to using new `edd_get_deliverable_order_item_statuses` function.

Proposed Changes:
This ended up being a bit thornier to sort through than initially intended due to previously ignoring `0` price IDs as actual price IDs. Also I think Berlin is doing something that maybe we don't want it to do and I need to look into that.
1. The primary change was to add a secondary set of checks to the `edd_order_grants_access_to_download_files` method to check for items being downloaded as part of a bundle, since the download URL will not contain the correct order item/price ID. This secondary check loops through all order items and checks if the current download/price ID combo matches a defined bundle item.
2. The `edd_process_signed_download_url` function has been updated to get the order object and use the properties from that instead of going through the payment meta backwards compatibility process.
3. That function was changing the price ID to an empty string before passing it to the "grants access" function if the price ID was empty, but that's incorrect since a price ID can legitimately be 0.
4. However, the "grants access" function needs to unset the price ID if it's `null` before handing off to Berlin, because it looks like Berlin casts that to `AND edd_oi.price_id = 0` instead of doing `IS NULL`.
5. In related places, I've checked through functions which use the `edd_get_download_file_url` function and made sure they correctly set the price ID to `null` as needed, and then changed that function to not add the price ID to the `eddfile` parameter if it is null, to remove potential casting of `null` to `0`. I expect this particular change to need to be scrutinized quite a bit, and there may still need to be a check if a `0` value is passed through when it should be `null`. Possibly the final bundle check in "grants access" could do a price ID check too since it's already looping through the items?
6. I've added a couple new unit tests and tweaked an existing one to cover some of the price ID gaps.

We should make sure all of the following still work:
- [ ] file download URLs in emails
- [ ] file download URLs in purchase receipts
- [ ] file download URLs in download history
- [ ] file download URLs in all access
- [ ] file download URLs copied from order tails
- [ ] file download URLs for single price items
- [ ] file download URLs for variably priced items
- [ ] file download URLs for bundled items
- [ ] SL download URLs
- [ ] free downloads URLs
Note: due to changes in how price IDs are handled, single price downloads should specifically be tested. Variable ones as well, but because we've used `0` interchangeably as both "no price ID" and an actual price ID this is the most likely potential failure point, I think.