### PR TITLE
Make found key check stricter

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -496,7 +496,7 @@ function edd_get_payment_status( $order, $return_label = false ) {
 	} else {
 		$keys      = edd_get_payment_status_keys();
 		$found_key = array_search( strtolower( $status ), $keys );
-		$status    = $found_key && array_key_exists( $found_key, $keys ) ? $keys[ $found_key ] : false;
+		$status    = false !== $found_key && array_key_exists( $found_key, $keys ) ? $keys[ $found_key ] : false;
 	}
 
 	return ! empty( $status ) ? $status : false;


### PR DESCRIPTION
Fixes #9181

Proposed Changes:
1. Compares `$found_key` explicitly to `false` as `0` is a valid array key.
