### PR TITLE
Update orders' contextual help

### DIFF
--- a/includes/admin/payments/contextual-help.php
+++ b/includes/admin/payments/contextual-help.php
@@ -45,7 +45,7 @@ function edd_payments_contextual_help() {
 		'id'	    => 'edd-payments-overview',
 		'title'	    => __( 'Overview', 'easy-digital-downloads' ),
 		'content'	=>
-			'<p>' . __( 'This screen provides access to all of the orders, refunds, and invoices in your store.', 'easy-digital-downloads' ) . '</p>' .
+			'<p>' . __( 'This screen provides access to all of the orders and refunds in your store.', 'easy-digital-downloads' ) . '</p>' .
 			'<p>' . __( 'Orders can be searched by email address, user name, or filtered by status, mode, date range, gateway, and more!', 'easy-digital-downloads' ) . '</p>' .
 			'<p>' . __( 'To maintain accurate reporting and accounting, we strongly advise against deleting any completed order data.', 'easy-digital-downloads' ) . '</p>'
 	) );
@@ -57,7 +57,7 @@ function edd_payments_contextual_help() {
 			'<p>' . __( 'Orders are placed by customers when they buy things from your store.', 'easy-digital-downloads' ) . '</p>' .
 			'<p>' . __( 'Every order contains a snapshot of your store at the time the order was placed, and is made up of many different pieces of information.', 'easy-digital-downloads' ) . '</p>' .
 			'<p>' . __( 'Things like products, discounts, taxes, fees, and customer email address, are all examples of information that is saved with each order.', 'easy-digital-downloads' ) . '</p>' .
-			'<p>' . __( 'Orders can be refunded entirely, or individual items can be refunded by editing an existing order.', 'easy-digital-downloads' ) . '</p>'
+			'<p>' . __( 'Both full and partial refunds are supported.', 'easy-digital-downloads' ) . '</p>'
 	) );
 
 	$screen->add_help_tab( array(
@@ -68,16 +68,6 @@ function edd_payments_contextual_help() {
 			'<p>' . __( 'Every refund refers back to the original order, and only contains the items and adjustments that were refunded.', 'easy-digital-downloads' ) . '</p>' .
 			'<p>' . __( 'Refunds could be entire orders, or single products.', 'easy-digital-downloads' ) . '</p>' .
 			'<p>' . __( 'Once an item is refunded, it cannot be undone; it can only be repurchased.', 'easy-digital-downloads' ) . '</p>'
-	) );
-
-	$screen->add_help_tab( array(
-		'id'	    => 'edd-invoice',
-		'title'	    => __( '&mdash; Invoices', 'easy-digital-downloads' ),
-		'content'	=>
-			'<p>' . __( 'Invoices are created by store admins as a way to request that a customer pay you for something.', 'easy-digital-downloads' ) . '</p>' .
-			'<p>' . __( 'Every invoice contains a snapshot of your store at the time the order was placed, and is made up of many different pieces of information.', 'easy-digital-downloads' ) . '</p>' .
-			'<p>' . __( 'Things like products, discounts, taxes, fees, and customer email address, are all examples of information that is saved with each invoice.', 'easy-digital-downloads' ) . '</p>' .
-			'<p>' . __( 'Invoices can be refunded entirely, or individual items can be refunded by editing an existing invoice.', 'easy-digital-downloads' ) . '</p>'
 	) );
 
 	$screen->add_help_tab( array(


### PR DESCRIPTION
Fixes #9186

Proposed Changes:
1. Removes the Invoices help tab and reference.
2. Updates the full/partial refund help text.
