### PR TITLE
Use payment ID as order number fallback

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -3419,7 +3419,7 @@ class EDD_Payment {
 	 * @return int|string Payment number.
 	 */
 	private function get_number() {
-		return $this->order->get_number();
+		return $this->order instanceof EDD\Orders\Order ? $this->order->get_number() : $this->ID;
 	}
 
 	/**

--- a/tests/tests-api.php
+++ b/tests/tests-api.php
@@ -367,6 +367,14 @@ class Tests_API extends EDD_UnitTestCase {
 		$this->assertEquals( 'Advanced', $out['sales'][0]['products'][0]['price_name'] );
 	}
 
+	public function test_get_recent_sales_invalid_payment_id() {
+		global $wp_query;
+		$wp_query->query_vars['id'] = 0;
+		$recent_sales               = self::$api->get_recent_sales();
+
+		$this->assertEquals( 0, $recent_sales['sales'][0]['ID'] );
+	}
+
 	public function test_update_key() {
 
 		$_POST['edd_set_api_key'] = 1;


### PR DESCRIPTION
Fixes #9199

Proposed Changes:
1. In `EDD_Payment::get_number()`, only query the order object if the order was retrieved. If not, fall back to the payment ID.
2. Adds a unit test for the `get_recent_sales()` API request which deliberately passes in an invalid payment ID.