### PR TITLE
Update PayPal Commerce Auto Register integration to inherit login state

### DIFF
--- a/includes/gateways/paypal/integrations.php
+++ b/includes/gateways/paypal/integrations.php
@@ -16,9 +16,10 @@ namespace EDD\Gateways\PayPal;
  * Added slightly early to not override anything more specific.
  *
  * @since 3.0
+ * @param bool $should_login Whether the new user shold be automatically logged in.
  * @return bool
  */
-function auto_register() {
-	return isset( $_POST['action'] ) && 'edd_capture_paypal_order' === $_POST['action'];
+function auto_register( $should_login ) {
+	return isset( $_POST['action'] ) && 'edd_capture_paypal_order' === $_POST['action'] ? true : $should_login;
 }
 add_filter( 'edd_auto_register_login_user', __NAMESPACE__ . '\auto_register', 5 );


### PR DESCRIPTION
Fixes #9205

Proposed Changes:
1. Includes the parameter for the filter and returns it as the fallback if the PayPal Commerce requirements are not met.