### PR TITLE
Update discount migration, legacy mapping

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -184,6 +184,18 @@ class Data_Migrator {
 				continue;
 			}
 
+			// `scope` has to be mapped uniquely.
+			if ( '_edd_discount_is_not_global' === $key ) {
+				$args['scope'] = ! empty( $value ) ? 'not_global' : 'global';
+				continue;
+			}
+
+			// `once_per_customer` has to be mapped uniquely.
+			if ( '_edd_discount_is_single_use' === $key ) {
+				$args['once_per_customer'] = ! empty( $value );
+				continue;
+			}
+
 			$value = maybe_unserialize( $value[0] );
 			$args[ str_replace( '_edd_discount_', '', $key ) ] = $value;
 		}

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -184,18 +184,6 @@ class Data_Migrator {
 				continue;
 			}
 
-			// `scope` has to be mapped uniquely.
-			if ( '_edd_discount_is_not_global' === $key ) {
-				$args['scope'] = ! empty( $value ) ? 'not_global' : 'global';
-				continue;
-			}
-
-			// `once_per_customer` has to be mapped uniquely.
-			if ( '_edd_discount_is_single_use' === $key ) {
-				$args['once_per_customer'] = ! empty( $value );
-				continue;
-			}
-
 			$value = maybe_unserialize( $value[0] );
 			$args[ str_replace( '_edd_discount_', '', $key ) ] = $value;
 		}

--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -1870,11 +1870,13 @@ class EDD_Discount extends Adjustment {
 			'products'          => 'product_reqs',
 			'excluded-products' => 'excluded_products',
 			'not_global'        => 'scope',
+			'is_not_global'     => 'scope',
 			'use_once'          => 'once_per_customer',
+			'is_single_use'     => 'once_per_customer',
 		);
 
 		foreach ( $old as $old_key => $new_key ) {
-			if ( 'not_global' === $old_key ) {
+			if ( in_array( $old_key, array( 'not_global', 'is_not_global' ), true ) && ! array_key_exists( 'scope', $args ) ) {
 				$args[ $new_key ] = ! empty( $args[ $old_key ] )
 					? 'not_global'
 					: 'global';

--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -1876,12 +1876,14 @@ class EDD_Discount extends Adjustment {
 		);
 
 		foreach ( $old as $old_key => $new_key ) {
-			if ( in_array( $old_key, array( 'not_global', 'is_not_global' ), true ) && ! array_key_exists( 'scope', $args ) ) {
-				$args[ $new_key ] = ! empty( $args[ $old_key ] )
-					? 'not_global'
-					: 'global';
-			} elseif ( isset( $args[ $old_key ] ) ) {
-				$args[ $new_key ] = $args[ $old_key ];
+			if ( isset( $args[ $old_key ] ) ) {
+				if ( in_array( $old_key, array( 'not_global', 'is_not_global' ), true ) && ! array_key_exists( 'scope', $args ) ) {
+					$args[ $new_key ] = ! empty( $args[ $old_key ] )
+						? 'not_global'
+						: 'global';
+				} else {
+					$args[ $new_key ] = $args[ $old_key ];
+				}
 			}
 			unset( $args[ $old_key ] );
 		}


### PR DESCRIPTION
Fixes #9218

Proposed Changes:
1. Adds back legacy keys removed in #8544, as they were what was breaking the migration.
2. Updates the `scope` check somewhat in the legacy mapping to only map values that exist in the passed parameters.