### PR TITLE
Return early if download object isn't retrieved

### DIFF
--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -147,11 +147,11 @@ function edd_is_free_download( $download_id = 0, $price_id = false ) {
  * @since 3.0
  *
  * @param int $download_id
- * @param int $price_id
+ * @param int|null $price_id
  *
- * @return string
+ * @return false|string
  */
-function edd_get_download_name( $download_id = 0, $price_id = 0 ) {
+function edd_get_download_name( $download_id = 0, $price_id = null ) {
 
 	// Bail if no download ID was passed.
 	if ( empty( $download_id ) || ! is_numeric( $download_id ) ) {

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -160,6 +160,11 @@ function edd_get_download_name( $download_id = 0, $price_id = 0 ) {
 
 	$download = edd_get_download( $download_id );
 
+	// Bail if the download cannot be retrieved.
+	if ( ! $download instanceof EDD_Download ) {
+		return false;
+	}
+
 	// Get the download title
 	$retval = $download->get_name();
 

--- a/tests/downloads/tests-download-functions.php
+++ b/tests/downloads/tests-download-functions.php
@@ -21,7 +21,7 @@ class Tests_Download_Functions extends EDD_UnitTestCase {
 		parent::tearDown();
 
 		EDD_Helper_Download::delete_download( $this->simple_download->ID );
-		EDD_Helper_Download::delete_downlad( $this->variable_download->ID );
+		EDD_Helper_Download::delete_download( $this->variable_download->ID );
 	}
 
 	/**

--- a/tests/downloads/tests-download-functions.php
+++ b/tests/downloads/tests-download-functions.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @group edd_downloads
+ * @group edd_functions
+ */
+class Tests_Download_Functions extends EDD_UnitTestCase {
+
+	protected $simple_download;
+
+	protected $variable_download;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->simple_download   = EDD_Helper_Download::create_simple_download();
+		$this->variable_download = EDD_Helper_Download::create_variable_download();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		EDD_Helper_Download::delete_download( $this->simple_download->ID );
+		EDD_Helper_Download::delete_downlad( $this->variable_download->ID );
+	}
+
+	/**
+	 * @covers edd_get_download_name
+	 */
+	public function test_get_download_name_simple_download_returns_name() {
+		$name = edd_get_download_name( $this->simple_download->ID );
+
+		$this->assertSame( 'Test Download Product', $name );
+	}
+
+	/**
+	 * @covers edd_get_download_name
+	 */
+	public function test_get_download_name_variable_download_returns_name() {
+		$name = edd_get_download_name( $this->variable_download->ID, 0 );
+
+		$this->assertSame( 'Variable Test Download Product — Simple', $name );
+	}
+
+	/**
+	 * @covers edd_get_download_name
+	 */
+	public function test_get_download_name_invalid_download_returns_false() {
+		$this->assertFalse( edd_get_download_name( 54657 ) );
+	}
+
+	/**
+	 * @covers edd_get_download_name
+	 */
+	public function test_get_download_name_invalid_download_id_returns_false() {
+		$this->assertFalse( edd_get_download_name( 'test' ) );
+	}
+}


### PR DESCRIPTION
Fixes #9226

Proposed Changes:
1. If `edd_get_download` does not return a download object, return early.

Noting two things that seem incorrect about the function:
1. The doc block says that it always returns a string, but it does already return `false` if no download ID is provided. I feel like this could be problematic if the function is used without extra logic. We do things if we can't find a customer, for example, like say "customer missing". Without extra checks on this, the download name could just be empty where its used. Maybe that's fine but we should update the doc block.
2. I think the default price ID parameter should be `null` instead of `0` as that's technically correct for no price ID.
