### PR TITLE
Update dashboard widgets message when CLI migration is running

### DIFF
--- a/includes/admin/dashboard-widgets.php
+++ b/includes/admin/dashboard-widgets.php
@@ -39,6 +39,14 @@ add_action('wp_dashboard_setup', 'edd_register_dashboard_widgets', 10 );
  */
 function edd_dashboard_sales_widget() {
 	if ( ! edd_has_upgrade_completed( 'migrate_orders' ) ) {
+		if ( get_option( 'edd_v30_cli_migration_running' ) ) {
+			printf(
+				'<p>%1$s %2$s</p>',
+				esc_html__( 'Easy Digital Downloads is performing a database migration via WP-CLI.', 'easy-digital-downloads' ),
+				esc_html__( 'This summary will be available when that has completed.', 'easy-digital-downloads' ),
+			);
+			return;
+		}
 		global $wpdb;
 		$orders = $wpdb->get_var( "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'edd_payment' LIMIT 1" );
 		if ( ! empty( $orders ) ) {
@@ -50,8 +58,9 @@ function edd_dashboard_sales_widget() {
 				admin_url( 'index.php' )
 			);
 			printf(
-				'<p>%1$s <a href="%2$s">%3$s</a></p>',
-				esc_html__( 'Easy Digital Downloads needs to upgrade the database. This summary will be available when that has completed.', 'easy-digital-downloads' ),
+				'<p>%1$s %2$s<a href="%3$s">%4$s</a></p>',
+				esc_html__( 'Easy Digital Downloads needs to upgrade the database.', 'easy-digital-downloads' ),
+				esc_html__( 'This summary will be available when that has completed.', 'easy-digital-downloads' ),
 				esc_url( $url ),
 				esc_html__( 'Begin the upgrade.', 'easy-digital-downloads' )
 			);

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -1746,5 +1746,8 @@ function edd_v30_is_migration_complete() {
 	// If the migration is complete, delete the pending option.
 	delete_option( 'edd_v3_migration_pending' );
 
+	// Delete the CLI option as well.
+	delete_option( 'edd_v30_cli_migration_running' );
+
 	return true;
 }

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -835,7 +835,6 @@ class EDD_CLI extends WP_CLI_Command {
 		$this->migrate_order_notes( $args, $assoc_args );
 		$this->migrate_customer_notes( $args, $assoc_args );
 		edd_v30_is_migration_complete();
-		delete_option( 'edd_v30_cli_migration_running' );
 		$this->remove_legacy_data( $args, $assoc_args );
 	}
 


### PR DESCRIPTION
Fixes #9232

Proposed Changes:
1. When the CLI migration is running, display the CLI migration message in the dashboard widget as well, instead of the link to the upgrade screen.
2. Moves the CLI option deletion out of the CLI class and into the `edd_v30_is_migration_complete` function. This runs in the CLI class right before the option was deleted, but this feels a little safer in that the option will be handled outside of the CLI, in case it fails to delete somehow there.