### PR TITLE
Only unset licensing/extensions settings tabs if empty

### DIFF
--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -88,7 +88,7 @@ function edd_options_page() {
 
 	// Remove tabs that don't have settings fields.
 	foreach ( array_keys( $settings_tabs ) as $settings_tab ) {
-		if ( empty( $all_settings[ $settings_tab ] ) ) {
+		if ( empty( $all_settings[ $settings_tab ] ) && in_array( $settings_tab, array( 'extensions', 'licenses' ), true ) ) {
 			unset( $settings_tabs[ $settings_tab ] );
 		}
 	}


### PR DESCRIPTION
Fixes #9225

Proposed Changes:
The break occurred in the PR for #9001, when `edd_get_settings_tabs` was refactored to be less expensive. That function checked if the licensing/extensions tabs were empty of settings and removed them if they were.

In its place, the `edd_options_page` function was updated to handle that check, but it checked all tabs, not just licensing and extensions, which is what broke settings added using the settings API, since the settings are registered differently than EDD core settings, I think.

This PR adjusts the check to only check the licensing and extensions tabs, which is more in line with the original code, and the sample tab/section now displays for me.