### PR TITLE
Move payment property assignments to order queries class

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -450,7 +450,8 @@ class EDD_Payment_History_Table extends List_Table {
 		$timezone_abbreviation = edd_get_timezone_abbr();
 		switch ( $column_name ) {
 			case 'amount':
-				$value = edd_display_amount( $order->total, $order->currency );
+				$currency = ! empty( $order->currency ) ? $order->currency : edd_get_currency();
+				$value    = edd_display_amount( $order->total, $currency );
 				break;
 			case 'date':
 				$value = '<time datetime="' . esc_attr( EDD()->utils->date( $order->date_created, null, true )->toDateTimeString() ) . '">' . edd_date_i18n( $order->date_created, 'M. d, Y' ) . '<br>' . edd_date_i18n( strtotime( $order->date_created ), 'H:i' ) . ' ' . $timezone_abbreviation . '</time>';
@@ -908,7 +909,7 @@ class EDD_Payment_History_Table extends List_Table {
 
 			$args['region'] = $region;
 		}
-		
+
 		/**
 		 * Filters array of arguments for getting orders for the list table, counts, and pagination.
 		 *

--- a/includes/database/engine/class-query.php
+++ b/includes/database/engine/class-query.php
@@ -1713,7 +1713,7 @@ class Query extends Base {
 	 * @since 1.0.0
 	 *
 	 * @param array $data
-	 * @return bool
+	 * @return false|int  Returns the item ID on success; false on failure.
 	 */
 	public function add_item( $data = array() ) {
 

--- a/includes/database/queries/class-order.php
+++ b/includes/database/queries/class-order.php
@@ -335,4 +335,31 @@ class Order extends Query {
 		$this->query_var_defaults['product_product_id'] = false;
 	}
 
+	/**
+	 * Adds an item to the database
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $data
+	 * @return bool
+	 */
+	public function add_item( $data = array() ) {
+		// Every order should have a currency assigned.
+		if ( empty( $data['currency'] ) ) {
+			$data['currency'] = edd_get_currency();
+		}
+
+		// If the payment key isn't already created, generate it.
+		if ( empty( $data['payment_key'] ) ) {
+			$email               = ! empty( $data['email'] ) ? $data['email'] : '';
+			$data['payment_key'] = edd_generate_order_payment_key( $email );
+		}
+
+		// Add the IP address if it hasn't been already.
+		if ( empty( $data['ip'] ) ) {
+			$data['ip'] = edd_get_ip();
+		}
+
+		return parent::add_item( $data );
+	}
 }

--- a/includes/database/queries/class-order.php
+++ b/includes/database/queries/class-order.php
@@ -341,7 +341,7 @@ class Order extends Query {
 	 * @since 3.0
 	 *
 	 * @param array $data
-	 * @return bool
+	 * @return false|int  Returns the item ID on success; false on failure.
 	 */
 	public function add_item( $data = array() ) {
 		// Every order should have a currency assigned.

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -810,12 +810,6 @@ class EDD_Payment {
 						) );
 						break;
 
-					case 'key':
-						edd_update_order( $this->ID, array(
-							'payment_key' => $this->key,
-						) );
-						break;
-
 					case 'tax_rate':
 						$tax_rate = $this->tax_rate > 1 ? $this->tax_rate : ( $this->tax_rate * 100 );
 						$this->update_meta( '_edd_payment_tax_rate', $tax_rate );
@@ -878,7 +872,6 @@ class EDD_Payment {
 				'downloads'    => $this->downloads,
 				'cart_details' => $this->cart_details,
 				'fees'         => $this->fees,
-				'currency'     => $this->currency,
 				'user_info'    => is_array( $this->user_info ) ? $this->user_info : array(),
 				'date'         => $this->date,
 				'email'        => $this->email,
@@ -902,8 +895,6 @@ class EDD_Payment {
 				'price'        => $this->total,
 				'date'         => $this->date,
 				'user_email'   => $this->email,
-				'purchase_key' => $this->key,
-				'currency'     => $this->currency,
 				'downloads'    => $this->downloads,
 				'user_info'    => array(
 					'id'         => $this->user_id,
@@ -924,9 +915,7 @@ class EDD_Payment {
 			if ( md5( serialize( $this->payment_meta ) ) !== md5( serialize( $merged_meta ) ) ) {
 				// First, update the order.
 				$order_info = array(
-					'payment_key' => $this->key,
-					'currency'    => $merged_meta['currency'],
-					'email'       => $merged_meta['email'],
+					'email' => $merged_meta['email'],
 				);
 
 				if ( isset( $merged_meta['user_info']['id'] ) ) {

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -810,6 +810,13 @@ class EDD_Payment {
 						) );
 						break;
 
+					case 'key':
+						edd_update_order( $this->ID, array(
+							'payment_key' => $this->key,
+						) );
+						break;
+
+
 					case 'tax_rate':
 						$tax_rate = $this->tax_rate > 1 ? $this->tax_rate : ( $this->tax_rate * 100 );
 						$this->update_meta( '_edd_payment_tax_rate', $tax_rate );

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -551,16 +551,6 @@ class EDD_Payment {
 	 * @return int|bool False on failure, the order ID on success.
 	 */
 	private function insert_payment() {
-		if ( empty( $this->key ) ) {
-			$auth_key             = defined( 'AUTH_KEY' ) ? AUTH_KEY : '';
-			$this->key            = strtolower( md5( $this->email . date( 'Y-m-d H:i:s' ) . $auth_key . uniqid( 'edd', true ) ) );  // Unique key
-			$this->pending['key'] = $this->key;
-		}
-
-		if ( empty( $this->ip ) ) {
-			$this->ip            = edd_get_ip();
-			$this->pending['ip'] = $this->ip;
-		}
 
 		$payment_data = array(
 			'price'        => $this->total,
@@ -737,12 +727,6 @@ class EDD_Payment {
 
 					case 'transaction_id':
 						$this->update_meta( 'transaction_id', $this->transaction_id );
-						break;
-
-					case 'ip':
-						edd_update_order( $this->ID, array(
-							'ip' => $this->ip,
-						) );
 						break;
 
 					case 'customer_id':


### PR DESCRIPTION
Fixes #9239

Proposed Changes:
1. Removes the fallback calculations for IP and payment key from the EDD_Payment class.
2. Extends the BerlinDB `add_item` method for orders and makes sure that every order has an IP, purchase key, and currency set when added to the database.

This needs to be tested with anything which manipulates/saves payments. Specifically, off the top of my head:
- [ ] Free Downloads
- [ ] Recurring
- [ ] Multi Currency