### PR TITLE
Fixes adding more than one additional customer email in admin

### DIFF
--- a/includes/admin/customers/customer-actions.php
+++ b/includes/admin/customers/customer-actions.php
@@ -222,12 +222,13 @@ function edd_add_customer_email( $args = array() ) {
 		);
 
 	} else {
-		$email       = sanitize_email( $args['email'] );
-		$customer_id = (int) $args['customer_id'];
-		$primary     = 'true' === $args['primary'] ? true : false;
-		$customer    = new EDD_Customer( $customer_id );
+		$email                  = sanitize_email( $args['email'] );
+		$customer_id            = (int) $args['customer_id'];
+		$primary                = 'true' === $args['primary'] ? true : false;
+		$customer               = new EDD_Customer( $customer_id );
+		$customer_email_address = $customer->add_email( $email, $primary );
 
-		if ( false === $customer->add_email( $email, $primary ) ) {
+		if ( false === $customer_email_address ) {
 
 			if ( in_array( $email, $customer->emails, true ) ) {
 				$output = array(
@@ -245,10 +246,11 @@ function edd_add_customer_email( $args = array() ) {
 		} else {
 			$redirect = edd_get_admin_url(
 				array(
-					'page'        => 'edd-customers',
-					'view'        => 'overview',
-					'id'          => urlencode( $customer_id ),
-					'edd-message' => 'email-added',
+					'page'         => 'edd-customers',
+					'view'         => 'overview',
+					'id'           => urlencode( $customer_id ),
+					'edd-message'  => 'email-added',
+					'edd-email-id' => $customer_email_address,
 				)
 			);
 			$output   = array(

--- a/includes/admin/customers/customer-actions.php
+++ b/includes/admin/customers/customer-actions.php
@@ -250,7 +250,7 @@ function edd_add_customer_email( $args = array() ) {
 					'view'         => 'overview',
 					'id'           => urlencode( $customer_id ),
 					'edd-message'  => 'email-added',
-					'edd-email-id' => $customer_email_address,
+					'edd-email-id' => $customer_email_id,
 				)
 			);
 			$output   = array(

--- a/includes/admin/customers/customer-actions.php
+++ b/includes/admin/customers/customer-actions.php
@@ -248,9 +248,9 @@ function edd_add_customer_email( $args = array() ) {
 				array(
 					'page'         => 'edd-customers',
 					'view'         => 'overview',
-					'id'           => urlencode( $customer_id ),
+					'id'           => absint( $customer_id ),
 					'edd-message'  => 'email-added',
-					'edd-email-id' => $customer_email_id,
+					'edd-email-id' => absint( $customer_email_id ),
 				)
 			);
 			$output   = array(

--- a/includes/admin/customers/customer-actions.php
+++ b/includes/admin/customers/customer-actions.php
@@ -222,13 +222,13 @@ function edd_add_customer_email( $args = array() ) {
 		);
 
 	} else {
-		$email                  = sanitize_email( $args['email'] );
-		$customer_id            = (int) $args['customer_id'];
-		$primary                = 'true' === $args['primary'] ? true : false;
-		$customer               = new EDD_Customer( $customer_id );
-		$customer_email_address = $customer->add_email( $email, $primary );
+		$email             = sanitize_email( $args['email'] );
+		$customer_id       = (int) $args['customer_id'];
+		$primary           = 'true' === $args['primary'] ? true : false;
+		$customer          = new EDD_Customer( $customer_id );
+		$customer_email_id = $customer->add_email( $email, $primary );
 
-		if ( false === $customer_email_address ) {
+		if ( false === $customer_email_id ) {
 
 			if ( in_array( $email, $customer->emails, true ) ) {
 				$output = array(

--- a/includes/class-edd-customer.php
+++ b/includes/class-edd-customer.php
@@ -365,6 +365,7 @@ class EDD_Customer extends \EDD\Database\Rows\Customer {
 	 * Attach an email address to the customer.
 	 *
 	 * @since 2.6
+	 * @since 3.0.1 This method will return customer email ID or false, instead of bool
 	 *
 	 * @param string $email The email address to remove from the customer.
 	 * @param bool   $primary Allows setting the email added as the primary.

--- a/includes/class-edd-customer.php
+++ b/includes/class-edd-customer.php
@@ -369,7 +369,7 @@ class EDD_Customer extends \EDD\Database\Rows\Customer {
 	 * @param string $email The email address to remove from the customer.
 	 * @param bool   $primary Allows setting the email added as the primary.
 	 *
-	 * @return bool True if the email was added successfully, false otherwise.
+	 * @return int|false ID of newly created customer email address, false on error.
 	 */
 	public function add_email( $email = '', $primary = false ) {
 		if ( ! is_email( $email ) ) {
@@ -389,11 +389,13 @@ class EDD_Customer extends \EDD\Database\Rows\Customer {
 			: 'secondary';
 
 		// Update is used to ensure duplicate emails are not added.
-		$ret = (bool) edd_add_customer_email_address( array(
-			'customer_id' => $this->id,
-			'email'       => $email,
-			'type'        => $type
-		) );
+		$ret = edd_add_customer_email_address(
+			array(
+				'customer_id' => $this->id,
+				'email'       => $email,
+				'type'        => $type,
+			)
+		);
 
 		do_action( 'edd_customer_post_add_email', $email, $this->id, $this );
 

--- a/tests/customers/tests-customers.php
+++ b/tests/customers/tests-customers.php
@@ -177,8 +177,8 @@ class Tests_Customers extends \EDD_UnitTestCase {
 		$this->assertCount( 0, parent::edd()->customer->create_and_get()->get_payment_ids() );
 	}
 
-	public function test_add_email_should_return_true() {
-		$this->assertTrue( self::$customers[1]->add_email( 'added-email@edd.test' ) );
+	public function test_add_email_should_return_id() {
+		$this->assertGreaterThanOrEqual( 1, self::$customers[1]->add_email( 'added-email@edd.test' ) );
 
 		/** @var $customer \EDD_Customer */
 		$customer = edd_get_customer( self::$customers[1]->id );
@@ -186,8 +186,8 @@ class Tests_Customers extends \EDD_UnitTestCase {
 		$this->assertTrue( in_array( 'added-email@edd.test', $customer->emails ) );
 	}
 
-	public function test_add_email_with_primary_parameter_should_return_true() {
-		$this->assertTrue( self::$customers[2]->add_email( 'added-email2@edd.test', true ) );
+	public function test_add_email_with_primary_parameter_should_return_id() {
+		$this->assertGreaterThanOrEqual( 1, self::$customers[2]->add_email( 'added-email2@edd.test', true ) );
 		$this->assertSame( 'added-email2@edd.test', self::$customers[2]->email );
 	}
 


### PR DESCRIPTION
Fixes #9254

When user is adding an additional customer email in the admin, the JS will refresh the page as per `response.redirect` parameter from the backend. It will work the first time because the URL of the page will change, but the page reload will stop working for any subsequent new emails, because the URL of the second refresh has not changed. If `window.location.href` is the same as the current page (with the # paramater), the page will not reload.

Proposed Changes:
- Added a unique parameter to each redirect response with the customer email ID, so that JS will always reliably reload the page
- Changed the `add_email` function inside `EDD_Customer` to return ID instead of boolean

