### PR TITLE
Fixed ambiguous date_created column inside taxed orders reports

### DIFF
--- a/includes/admin/reporting/export/class-batch-export-file-downloads.php
+++ b/includes/admin/reporting/export/class-batch-export-file-downloads.php
@@ -68,7 +68,7 @@ class EDD_Batch_File_Downloads_Export extends EDD_Batch_Export {
 		);
 
 		if ( ! empty( $this->start ) || ! empty( $this->end ) ) {
-			$args['date_query'] = $this->get_date_query();
+			$args['date_created_query'] = $this->get_date_query();
 		}
 
 		if ( 0 !== $this->download_id ) {
@@ -129,7 +129,7 @@ class EDD_Batch_File_Downloads_Export extends EDD_Batch_Export {
 		);
 
 		if ( ! empty( $this->start ) || ! empty( $this->end ) ) {
-			$args['date_query'] = $this->get_date_query();
+			$args['date_created_query'] = $this->get_date_query();
 		}
 
 		if ( 0 !== $this->download_id ) {

--- a/includes/admin/reporting/export/class-batch-export-taxed-orders.php
+++ b/includes/admin/reporting/export/class-batch-export-taxed-orders.php
@@ -98,7 +98,7 @@ class EDD_Batch_Taxed_Orders_Export extends EDD_Batch_Export {
 		);
 
 		if ( ! empty( $this->start ) || ! empty( $this->end ) ) {
-			$args['date_query'] = $this->get_date_query();
+			$args['date_created_query'] = $this->get_date_query();
 		}
 
 		if ( 'any' === $args['status'] || 'all' === $args['status'] ) {

--- a/includes/admin/reporting/export/class-batch-export-taxed-orders.php
+++ b/includes/admin/reporting/export/class-batch-export-taxed-orders.php
@@ -238,7 +238,7 @@ class EDD_Batch_Taxed_Orders_Export extends EDD_Batch_Export {
 		);
 
 		if ( ! empty( $this->start ) || ! empty( $this->end ) ) {
-			$args['date_query'] = $this->get_date_query();
+			$args['date_created_query'] = $this->get_date_query();
 		}
 
 		if ( 'any' !== $this->status ) {


### PR DESCRIPTION
Fixes #9165

Proposed change:
- The field `date_created` is ambiguous when you export taxed orders while selecting date filter + country filter. I have made a change inside `class-batch-export-taxed-orders.php` so that Berlin will append the table alias to the `date_created` field.