### PR TITLE
Do not generate structured download data if a download cannot be retrieved

### DIFF
--- a/includes/class-structured-data.php
+++ b/includes/class-structured-data.php
@@ -129,6 +129,11 @@ class Structured_Data {
 			return false;
 		}
 
+		// Return false if a download object could not be retrieved.
+		if ( ! $download instanceof \EDD_Download ) {
+			return false;
+		}
+
 		$data = array(
 			'@type'       => 'Product',
 			'name'        => $download->post_title,

--- a/tests/tests-structured-data.php
+++ b/tests/tests-structured-data.php
@@ -74,9 +74,10 @@ class Tests_Structured_Data extends EDD_UnitTestCase {
 	public function test_generate_download_data() {
 		EDD()->structured_data->generate_download_data( self::$download->ID );
 
-		$data = EDD()->structured_data->get_data();
+		$all_data = EDD()->structured_data->get_data();
+		$data     = reset( $all_data );
 
-		$this->assertEquals( self::$download->post_title, $data[1]['name'] );
+		$this->assertEquals( self::$download->post_title, $data['name'] );
 	}
 
 	/**

--- a/tests/tests-structured-data.php
+++ b/tests/tests-structured-data.php
@@ -64,6 +64,13 @@ class Tests_Structured_Data extends EDD_UnitTestCase {
 	/**
 	 * @covers EDD_Structured_Data::generate_download_data()
 	 */
+	public function test_generate_download_data_for_non_download_should_return_false() {
+		$this->assertFalse( EDD()->structured_data->generate_download_data( 2341234 ) );
+	}
+
+	/**
+	 * @covers EDD_Structured_Data::generate_download_data()
+	 */
 	public function test_generate_download_data() {
 		EDD()->structured_data->generate_download_data( self::$download->ID );
 


### PR DESCRIPTION
Fixes #9279

Proposed Changes:
1. Change `generate_download_data` to return early if `edd_get_download` doesn't return a download.
2. Updates the related unit test and adds a new one.
