### PR TITLE
Fix/mysql 55

### DIFF
--- a/includes/database/NotificationsDB.php
+++ b/includes/database/NotificationsDB.php
@@ -252,7 +252,16 @@ class NotificationsDB extends \EDD_DB {
 	    KEY dismissed_start_end (dismissed, start, end)
 		) DEFAULT CHARACTER SET {$wpdb->charset} COLLATE {$wpdb->collate};" );
 
+		// Update `date_created`.
+		$wpdb->query(
+			"ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00'"
+		);
+
+		// Update `date_updated`.
+		$wpdb->query(
+			"ALTER TABLE {$this->table_name} MODIFY COLUMN `date_updated` datetime NOT NULL default '0000-00-00 00:00:00'"
+		);
+
 		update_option( $this->table_name . '_db_version', $this->version );
 	}
-
 }

--- a/includes/database/NotificationsDB.php
+++ b/includes/database/NotificationsDB.php
@@ -24,7 +24,7 @@ class NotificationsDB extends \EDD_DB {
 
 		$this->table_name  = $wpdb->prefix . 'edd_notifications';
 		$this->primary_key = 'id';
-		$this->version     = '1.0';
+		$this->version     = '1.0.1';
 
 		add_action( 'edd_daily_scheduled_events', array( $this, 'schedule_daily_notification_checks' ) );
 
@@ -246,8 +246,8 @@ class NotificationsDB extends \EDD_DB {
 	    start datetime DEFAULT NULL,
 	    end datetime DEFAULT NULL,
 	    dismissed tinyint(1) UNSIGNED NOT NULL DEFAULT 0,
-	    date_created datetime NOT NULL DEFAULT CURRENT_TIMESTAMP(),
-	    date_updated datetime NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+	    date_created datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+	    date_updated datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 	    PRIMARY KEY (id),
 	    KEY dismissed_start_end (dismissed, start, end)
 		) DEFAULT CHARACTER SET {$wpdb->charset} COLLATE {$wpdb->collate};" );

--- a/includes/database/schemas/class-adjustments.php
+++ b/includes/database/schemas/class-adjustments.php
@@ -186,7 +186,7 @@ final class Adjustments extends Schema {
 		array(
 			'name'       => 'date_created',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'created'    => true,
 			'date_query' => true,
 			'sortable'   => true
@@ -196,7 +196,7 @@ final class Adjustments extends Schema {
 		array(
 			'name'       => 'date_modified',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'modified'   => true,
 			'date_query' => true,
 			'sortable'   => true

--- a/includes/database/schemas/class-customer-addresses.php
+++ b/includes/database/schemas/class-customer-addresses.php
@@ -145,7 +145,7 @@ class Customer_Addresses extends Schema {
 		array(
 			'name'       => 'date_created',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'created'    => true,
 			'date_query' => true,
 			'sortable'   => true
@@ -155,7 +155,7 @@ class Customer_Addresses extends Schema {
 		array(
 			'name'       => 'date_modified',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'modified'   => true,
 			'date_query' => true,
 			'sortable'   => true

--- a/includes/database/schemas/class-customer-email-addresses.php
+++ b/includes/database/schemas/class-customer-email-addresses.php
@@ -88,7 +88,7 @@ class Customer_Email_Addresses extends Schema {
 		array(
 			'name'       => 'date_created',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'created'    => true,
 			'date_query' => true,
 			'sortable'   => true
@@ -98,7 +98,7 @@ class Customer_Email_Addresses extends Schema {
 		array(
 			'name'       => 'date_modified',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'modified'   => true,
 			'date_query' => true,
 			'sortable'   => true

--- a/includes/database/schemas/class-customers.php
+++ b/includes/database/schemas/class-customers.php
@@ -104,7 +104,7 @@ class Customers extends Schema {
 		array(
 			'name'       => 'date_created',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'created'    => true,
 			'date_query' => true,
 			'sortable'   => true
@@ -114,7 +114,7 @@ class Customers extends Schema {
 		array(
 			'name'       => 'date_modified',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'modified'   => true,
 			'date_query' => true,
 			'sortable'   => true

--- a/includes/database/schemas/class-logs-api-requests.php
+++ b/includes/database/schemas/class-logs-api-requests.php
@@ -124,7 +124,7 @@ class Logs_Api_Requests extends Schema {
 		array(
 			'name'       => 'date_created',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'created'    => true,
 			'date_query' => true,
 			'sortable'   => true
@@ -134,7 +134,7 @@ class Logs_Api_Requests extends Schema {
 		array(
 			'name'       => 'date_modified',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'modified'   => true,
 			'date_query' => true,
 			'sortable'   => true

--- a/includes/database/schemas/class-logs-file-downloads.php
+++ b/includes/database/schemas/class-logs-file-downloads.php
@@ -115,7 +115,7 @@ class Logs_File_Downloads extends Schema {
 		array(
 			'name'       => 'date_created',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'created'    => true,
 			'date_query' => true,
 			'sortable'   => true
@@ -125,7 +125,7 @@ class Logs_File_Downloads extends Schema {
 		array(
 			'name'       => 'date_modified',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'modified'   => true,
 			'date_query' => true,
 			'sortable'   => true

--- a/includes/database/schemas/class-logs.php
+++ b/includes/database/schemas/class-logs.php
@@ -110,7 +110,7 @@ class Logs extends Schema {
 		array(
 			'name'       => 'date_created',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'created'    => true,
 			'date_query' => true,
 			'sortable'   => true
@@ -120,7 +120,7 @@ class Logs extends Schema {
 		array(
 			'name'       => 'date_modified',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'modified'   => true,
 			'date_query' => true,
 			'sortable'   => true

--- a/includes/database/schemas/class-notes.php
+++ b/includes/database/schemas/class-notes.php
@@ -85,7 +85,7 @@ class Notes extends Schema {
 		array(
 			'name'       => 'date_created',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'created'    => true,
 			'date_query' => true,
 			'sortable'   => true
@@ -95,7 +95,7 @@ class Notes extends Schema {
 		array(
 			'name'       => 'date_modified',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'modified'   => true,
 			'date_query' => true,
 			'sortable'   => true

--- a/includes/database/schemas/class-order-addresses.php
+++ b/includes/database/schemas/class-order-addresses.php
@@ -124,7 +124,7 @@ class Order_Addresses extends Schema {
 		array(
 			'name'       => 'date_created',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'created'    => true,
 			'date_query' => true,
 			'sortable'   => true
@@ -134,7 +134,7 @@ class Order_Addresses extends Schema {
 		array(
 			'name'       => 'date_modified',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'modified'   => true,
 			'date_query' => true,
 			'sortable'   => true

--- a/includes/database/schemas/class-order-adjustments.php
+++ b/includes/database/schemas/class-order-adjustments.php
@@ -154,7 +154,7 @@ class Order_Adjustments extends Schema {
 		array(
 			'name'       => 'date_created',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'created'    => true,
 			'date_query' => true,
 			'sortable'   => true
@@ -164,7 +164,7 @@ class Order_Adjustments extends Schema {
 		array(
 			'name'       => 'date_modified',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'modified'   => true,
 			'date_query' => true,
 			'sortable'   => true

--- a/includes/database/schemas/class-order-items.php
+++ b/includes/database/schemas/class-order-items.php
@@ -195,7 +195,7 @@ class Order_Items extends Schema {
 		array(
 			'name'       => 'date_created',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'created'    => true,
 			'date_query' => true,
 			'sortable'   => true
@@ -205,7 +205,7 @@ class Order_Items extends Schema {
 		array(
 			'name'       => 'date_modified',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'modified'   => true,
 			'date_query' => true,
 			'sortable'   => true

--- a/includes/database/schemas/class-order-transactions.php
+++ b/includes/database/schemas/class-order-transactions.php
@@ -110,7 +110,7 @@ class Order_Transactions extends Schema {
 		array(
 			'name'       => 'date_created',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'created'    => true,
 			'date_query' => true,
 			'sortable'   => true
@@ -120,7 +120,7 @@ class Order_Transactions extends Schema {
 		array(
 			'name'       => 'date_modified',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'modified'   => true,
 			'date_query' => true,
 			'sortable'   => true

--- a/includes/database/schemas/class-orders.php
+++ b/includes/database/schemas/class-orders.php
@@ -210,7 +210,7 @@ class Orders extends Schema {
 		array(
 			'name'       => 'date_created',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'created'    => true,
 			'date_query' => true,
 			'sortable'   => true
@@ -220,7 +220,7 @@ class Orders extends Schema {
 		array(
 			'name'       => 'date_modified',
 			'type'       => 'datetime',
-			'default'    => '', // Defaults to current time in query class
+			'default'    => '0000-00-00 00:00:00',
 			'modified'   => true,
 			'date_query' => true,
 			'sortable'   => true

--- a/includes/database/tables/class-adjustments.php
+++ b/includes/database/tables/class-adjustments.php
@@ -38,7 +38,7 @@ final class Adjustments extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 202102161;
+	protected $version = 202207161;
 
 	/**
 	 * Array of upgrade versions and methods.
@@ -50,7 +50,8 @@ final class Adjustments extends Table {
 	protected $upgrades = array(
 		'201906031' => 201906031,
 		'202002121' => 202002121,
-		'202102161' => 202102161
+		'202102161' => 202102161,
+		'202207161' => 202207161,
 	);
 
 	/**
@@ -76,8 +77,8 @@ final class Adjustments extends Table {
 			min_charge_amount decimal(18,9) NOT NULL default '0',
 			start_date datetime default null,
 			end_date datetime default null,
-			date_created datetime NOT NULL default CURRENT_TIMESTAMP,
-			date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
+			date_created datetime NOT NULL default '0000-00-00 00:00:00',
+			date_modified datetime NOT NULL default '0000-00-00 00:00:00',
 			uuid varchar(100) NOT NULL default '',
 			PRIMARY KEY (id),
 			KEY type_status (type(20), status(20)),
@@ -100,17 +101,15 @@ final class Adjustments extends Table {
 		// After successful creation, we need to set the auto_increment for legacy orders.
 		if ( ! empty( $created ) ) {
 
-			$result = $this->get_db()->get_var( "SELECT ID FROM {$this->get_db()->prefix}posts WHERE post_type = 'edd_discount' ORDER BY ID DESC LIMIT 1;" );
+			$result = $this->get_db()->get_var( "SELECT ID FROM {$this->get_db()->prefix}posts WHERE post_type = 'edd_discount' ORDER BY ID DESC LIMIT 1" );
 
 			if ( ! empty( $result )  ) {
 				$auto_increment = $result + 1;
-				$this->get_db()->query( "ALTER TABLE {$this->table_name}  AUTO_INCREMENT = {$auto_increment};" );
+				$this->get_db()->query( "ALTER TABLE {$this->table_name} AUTO_INCREMENT = {$auto_increment}" );
 			}
-
 		}
 
 		return $created;
-
 	}
 
 	/**
@@ -146,7 +145,6 @@ final class Adjustments extends Table {
 	/**
 	 * Upgrade to version 202002121
 	 *  - Change default value to `null` for columns `start_date` and `end_date`.
-	 *  - Change default value to `CURRENT_TIMESTAMP` for columns `date_created` and `date_modified`.
 	 *
 	 * @return bool
 	 */
@@ -154,7 +152,7 @@ final class Adjustments extends Table {
 
 		// Update `start_date`.
 		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `start_date` datetime default null;
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `start_date` datetime default null
 		" );
 
 		if ( $this->is_success( $result ) ) {
@@ -163,25 +161,14 @@ final class Adjustments extends Table {
 
 		// Update `end_date`.
 		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `end_date` datetime default null;
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `end_date` datetime default null
 		" );
 
 		if ( $this->is_success( $result ) ) {
 			$this->get_db()->query( "UPDATE {$this->table_name} SET `end_date` = NULL WHERE `end_date` = '0000-00-00 00:00:00'" );
 		}
 
-		// Update `date_created`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default CURRENT_TIMESTAMP;
-		" );
-
-		// Update `date_modified`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default CURRENT_TIMESTAMP;
-		" );
-
 		return $this->is_success( $result );
-
 	}
 
 	/**
@@ -200,6 +187,28 @@ final class Adjustments extends Table {
 
 		$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX type_status (type(20), status(20))" );
 		$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX code (code)" );
+
+		return true;
+	}
+
+	/**
+	 * Upgrade to version 202207161
+	 *  - Change default value to '0000-00-00 00:00:00' for columns `date_created` and `date_modified`.
+	 *
+	 * @since 3.0.2
+	 * @return bool
+	 */
+	protected function __202207161() {
+
+		// Update `date_created`.
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00'
+		" );
+
+		// Update `date_modified`.
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00'
+		" );
 
 		return true;
 	}

--- a/includes/database/tables/class-customer-addresses.php
+++ b/includes/database/tables/class-customer-addresses.php
@@ -38,7 +38,7 @@ final class Customer_Addresses extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 202004051;
+	protected $version = 202207161;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -49,8 +49,8 @@ final class Customer_Addresses extends Table {
 	 */
 	protected $upgrades = array(
 		'201906251' => 201906251,
-		'202002141' => 202002141,
 		'202004051' => 202004051,
+		'202207161' => 202207161,
 	);
 
 	/**
@@ -73,8 +73,8 @@ final class Customer_Addresses extends Table {
 			region mediumtext NOT NULL,
 			postal_code varchar(32) NOT NULL default '',
 			country mediumtext NOT NULL,
-			date_created datetime NOT NULL default CURRENT_TIMESTAMP,
-			date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
+			date_created datetime NOT NULL default '0000-00-00 00:00:00',
+			date_modified datetime NOT NULL default '0000-00-00 00:00:00',
 			uuid varchar(100) NOT NULL default '',
 			PRIMARY KEY (id),
 			KEY customer_is_primary (customer_id, is_primary),
@@ -97,34 +97,11 @@ final class Customer_Addresses extends Table {
 
 		if ( false === $result ) {
 			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `name` mediumtext AFTER `status`;
+				ALTER TABLE {$this->table_name} ADD COLUMN `name` mediumtext AFTER `status`
 			" );
 		}
 
 		return $this->is_success( $result );
-	}
-
-	/**
-	 * Upgrade to version 202002141
-	 *  - Change default value to `CURRENT_TIMESTAMP` for columns `date_created` and `date_modified`.
-	 *
-	 * @since 3.0
-	 * @return bool
-	 */
-	protected function __202002141() {
-
-		// Update `date_created`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default CURRENT_TIMESTAMP;
-		" );
-
-		// Update `date_modified`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default CURRENT_TIMESTAMP;
-		" );
-
-		return $this->is_success( $result );
-
 	}
 
 	/**
@@ -137,13 +114,35 @@ final class Customer_Addresses extends Table {
 	protected function __202004051() {
 
 		$result = $this->column_exists( 'is_primary' );
+
 		if ( false === $result ) {
 			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `is_primary` tinyint SIGNED NOT NULL default '0' AFTER `customer_id`;
+				ALTER TABLE {$this->table_name} ADD COLUMN `is_primary` tinyint SIGNED NOT NULL default '0' AFTER `customer_id`
 			" );
 		}
 
 		return $this->is_success( $result );
 	}
 
+	/**
+	 * Upgrade to version 202207161
+	 *  - Change default value to '0000-00-00 00:00:00' for columns `date_created` and `date_modified`.
+	 *
+	 * @since 3.0.2
+	 * @return bool
+	 */
+	protected function __202207161() {
+
+		// Update `date_created`.
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00'
+		" );
+
+		// Update `date_modified`.
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00'
+		" );
+
+		return true;
+	}
 }

--- a/includes/database/tables/class-customer-email-addresses.php
+++ b/includes/database/tables/class-customer-email-addresses.php
@@ -38,7 +38,7 @@ final class Customer_Email_Addresses extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 202002141;
+	protected $version = 202207161;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,7 +48,7 @@ final class Customer_Email_Addresses extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'202002141' => 202002141,
+		'202207161' => 202207161,
 	);
 
 	/**
@@ -64,8 +64,8 @@ final class Customer_Email_Addresses extends Table {
 			type varchar(20) NOT NULL default 'secondary',
 			status varchar(20) NOT NULL default 'active',
 			email varchar(100) NOT NULL default '',
-			date_created datetime NOT NULL default CURRENT_TIMESTAMP,
-			date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
+			date_created datetime NOT NULL default '0000-00-00 00:00:00',
+			date_modified datetime NOT NULL default '0000-00-00 00:00:00',
 			uuid varchar(100) NOT NULL default '',
 			PRIMARY KEY (id),
 			KEY customer (customer_id),
@@ -76,26 +76,24 @@ final class Customer_Email_Addresses extends Table {
 	}
 
 	/**
-	 * Upgrade to version 202002141
-	 *  - Change default value to `CURRENT_TIMESTAMP` for columns `date_created` and `date_modified`.
+	 * Upgrade to version 202207161
+	 *  - Change default value to '0000-00-00 00:00:00' for columns `date_created` and `date_modified`.
 	 *
-	 * @since 3.0
+	 * @since 3.0.2
 	 * @return bool
 	 */
-	protected function __202002141() {
+	protected function __202207161() {
 
 		// Update `date_created`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default CURRENT_TIMESTAMP;
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00'
 		" );
 
 		// Update `date_modified`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default CURRENT_TIMESTAMP;
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00'
 		" );
 
-		return $this->is_success( $result );
-
+		return true;
 	}
-
 }

--- a/includes/database/tables/class-customers.php
+++ b/includes/database/tables/class-customers.php
@@ -38,7 +38,7 @@ final class Customers extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 202006101;
+	protected $version = 202207161;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,8 +48,8 @@ final class Customers extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'202002141' => 202002141,
 		'202006101' => 202006101,
+		'202207161' => 202207161,
 	);
 
 	/**
@@ -67,8 +67,8 @@ final class Customers extends Table {
 			status varchar(20) NOT NULL default '',
 			purchase_value decimal(18,9) NOT NULL default '0',
 			purchase_count bigint(20) unsigned NOT NULL default '0',
-			date_created datetime NOT NULL default CURRENT_TIMESTAMP,
-			date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
+			date_created datetime NOT NULL default '0000-00-00 00:00:00',
+			date_modified datetime NOT NULL default '0000-00-00 00:00:00',
 			uuid varchar(100) NOT NULL default '',
 			PRIMARY KEY (id),
 			UNIQUE KEY email (email),
@@ -99,48 +99,24 @@ final class Customers extends Table {
 			$this->get_db()->query( "ALTER TABLE {$this->table_name} MODIFY `user_id` bigint(20) unsigned NOT NULL default '0'" );
 			$this->get_db()->query( "ALTER TABLE {$this->table_name} MODIFY `purchase_value` decimal(18,9) NOT NULL default '0'" );
 			$this->get_db()->query( "ALTER TABLE {$this->table_name} MODIFY `purchase_count` bigint(20) unsigned NOT NULL default '0'" );
-			$this->get_db()->query( "ALTER TABLE {$this->table_name} MODIFY `date_created` datetime NOT NULL default CURRENT_TIMESTAMP" );
 
 			if ( ! $this->column_exists( 'status' ) ) {
-				$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN `status` varchar(20) NOT NULL default 'active' AFTER `name`;" );
+				$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN `status` varchar(20) NOT NULL default 'active' AFTER `name`" );
 				$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX status (status(20))" );
 			}
 
 			if ( ! $this->column_exists( 'date_modified' ) ) {
-				$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN `date_modified` datetime DEFAULT CURRENT_TIMESTAMP AFTER `date_created`" );
+				$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00' AFTER `date_created`" );
 				$this->get_db()->query( "UPDATE {$this->table_name} SET `date_modified` = `date_created`" );
 				$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX date_created (date_created)" );
 			}
 
 			if ( ! $this->column_exists( 'uuid' ) ) {
-				$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;" );
+				$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`" );
 			}
 		}
 
 		parent::maybe_upgrade();
-	}
-
-	/**
-	 * Upgrade to version 202002141
-	 *  - Change default value to `CURRENT_TIMESTAMP` for columns `date_created` and `date_modified`.
-	 *
-	 * @since 3.0
-	 * @return bool
-	 */
-	protected function __202002141() {
-
-		// Update `date_created`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default CURRENT_TIMESTAMP;
-		" );
-
-		// Update `date_modified`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default CURRENT_TIMESTAMP;
-		" );
-
-		return $this->is_success( $result );
-
 	}
 
 	/**
@@ -164,4 +140,25 @@ final class Customers extends Table {
 		return $this->is_success( $result );
 	}
 
+	/**
+	 * Upgrade to version 202207161
+	 *  - Change default value to '0000-00-00 00:00:00' for columns `date_created` and `date_modified`.
+	 *
+	 * @since 3.0.2
+	 * @return bool
+	 */
+	protected function __202207161() {
+
+		// Update `date_created`.
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00'
+		" );
+
+		// Update `date_modified`.
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00'
+		" );
+
+		return true;
+	}
 }

--- a/includes/database/tables/class-logs-api-requests.php
+++ b/includes/database/tables/class-logs-api-requests.php
@@ -38,7 +38,7 @@ final class Logs_Api_Requests extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 202002141;
+	protected $version = 202207161;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,7 +48,7 @@ final class Logs_Api_Requests extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'202002141' => 202002141,
+		'202207161' => 202207161,
 	);
 
 	/**
@@ -68,8 +68,8 @@ final class Logs_Api_Requests extends Table {
 		error longtext NOT NULL default '',
 		ip varchar(60) NOT NULL default '',
 		time varchar(60) NOT NULL default '',
-		date_created datetime NOT NULL default CURRENT_TIMESTAMP,
-		date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
+		date_created datetime NOT NULL default '0000-00-00 00:00:00',
+		date_modified datetime NOT NULL default '0000-00-00 00:00:00',
 		uuid varchar(100) NOT NULL default '',
 		PRIMARY KEY (id),
 		KEY user_id (user_id),
@@ -77,26 +77,24 @@ final class Logs_Api_Requests extends Table {
 	}
 
 	/**
-	 * Upgrade to version 202002141
-	 *  - Change default value to `CURRENT_TIMESTAMP` for columns `date_created` and `date_modified`.
+	 * Upgrade to version 202207161
+	 *  - Change default value to '0000-00-00 00:00:00' for columns `date_created` and `date_modified`.
 	 *
-	 * @since 3.0
+	 * @since 3.0.2
 	 * @return bool
 	 */
-	protected function __202002141() {
+	protected function __202207161() {
 
 		// Update `date_created`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default CURRENT_TIMESTAMP;
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00'
 		" );
 
 		// Update `date_modified`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default CURRENT_TIMESTAMP;
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00'
 		" );
 
-		return $this->is_success( $result );
-
+		return true;
 	}
-
 }

--- a/includes/database/tables/class-logs-file-downloads.php
+++ b/includes/database/tables/class-logs-file-downloads.php
@@ -38,7 +38,7 @@ final class Logs_File_Downloads extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 202002141;
+	protected $version = 202207161;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,7 +48,7 @@ final class Logs_File_Downloads extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'202002141' => 202002141,
+		'202207161' => 202207161,
 	);
 
 	/**
@@ -67,8 +67,8 @@ final class Logs_File_Downloads extends Table {
 		customer_id bigint(20) unsigned NOT NULL default '0',
 		ip varchar(60) NOT NULL default '',
 		user_agent varchar(200) NOT NULL default '',
-		date_created datetime NOT NULL default CURRENT_TIMESTAMP,
-		date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
+		date_created datetime NOT NULL default '0000-00-00 00:00:00',
+		date_modified datetime NOT NULL default '0000-00-00 00:00:00',
 		uuid varchar(100) NOT NULL default '',
 		PRIMARY KEY (id),
 		KEY customer_id (customer_id),
@@ -77,26 +77,24 @@ final class Logs_File_Downloads extends Table {
 	}
 
 	/**
-	 * Upgrade to version 202002141
-	 *  - Change default value to `CURRENT_TIMESTAMP` for columns `date_created` and `date_modified`.
+	 * Upgrade to version 202207161
+	 *  - Change default value to '0000-00-00 00:00:00' for columns `date_created` and `date_modified`.
 	 *
-	 * @since 3.0
+	 * @since 3.0.2
 	 * @return bool
 	 */
-	protected function __202002141() {
+	protected function __202207161() {
 
 		// Update `date_created`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default CURRENT_TIMESTAMP;
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00'
 		" );
 
 		// Update `date_modified`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default CURRENT_TIMESTAMP;
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00'
 		" );
 
-		return $this->is_success( $result );
-
+		return true;
 	}
-
 }

--- a/includes/database/tables/class-logs.php
+++ b/includes/database/tables/class-logs.php
@@ -38,7 +38,7 @@ final class Logs extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 202002141;
+	protected $version = 202207161;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,7 +48,7 @@ final class Logs extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'202002141' => 202002141,
+		'202207161' => 202207161,
 	);
 
 	/**
@@ -66,8 +66,8 @@ final class Logs extends Table {
 		type varchar(20) DEFAULT NULL,
 		title varchar(200) DEFAULT NULL,
 		content longtext DEFAULT NULL,
-		date_created datetime NOT NULL default CURRENT_TIMESTAMP,
-		date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
+		date_created datetime NOT NULL default '0000-00-00 00:00:00',
+		date_modified datetime NOT NULL default '0000-00-00 00:00:00',
 		uuid varchar(100) NOT NULL default '',
 		PRIMARY KEY (id),
 		KEY object_id_type (object_id,object_type(20)),
@@ -77,25 +77,24 @@ final class Logs extends Table {
 	}
 
 	/**
-	 * Upgrade to version 202002141
-	 *  - Change default value to `CURRENT_TIMESTAMP` for columns `date_created` and `date_modified`.
+	 * Upgrade to version 202207161
+	 *  - Change default value to '0000-00-00 00:00:00' for columns `date_created` and `date_modified`.
 	 *
-	 * @since 3.0
+	 * @since 3.0.2
 	 * @return bool
 	 */
-	protected function __202002141() {
+	protected function __202207161() {
 
 		// Update `date_created`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default CURRENT_TIMESTAMP;
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00'
 		" );
 
 		// Update `date_modified`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default CURRENT_TIMESTAMP;
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00'
 		" );
 
-		return $this->is_success( $result );
-
+		return true;
 	}
 }

--- a/includes/database/tables/class-notes.php
+++ b/includes/database/tables/class-notes.php
@@ -38,7 +38,7 @@ final class Notes extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 202002141;
+	protected $version = 202207161;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,7 +48,7 @@ final class Notes extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'202002141' => 202002141,
+		'202207161' => 202207161,
 	);
 
 	/**
@@ -64,8 +64,8 @@ final class Notes extends Table {
 			object_type varchar(20) NOT NULL default '',
 			user_id bigint(20) unsigned NOT NULL default '0',
 			content longtext NOT NULL default '',
-			date_created datetime NOT NULL default CURRENT_TIMESTAMP,
-			date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
+			date_created datetime NOT NULL default '0000-00-00 00:00:00',
+			date_modified datetime NOT NULL default '0000-00-00 00:00:00',
 			uuid varchar(100) NOT NULL default '',
 			PRIMARY KEY (id),
 			KEY object_id_type (object_id,object_type(20)),
@@ -74,26 +74,24 @@ final class Notes extends Table {
 	}
 
 	/**
-	 * Upgrade to version 202002141
-	 *  - Change default value to `CURRENT_TIMESTAMP` for columns `date_created` and `date_modified`.
+	 * Upgrade to version 202207161
+	 *  - Change default value to '0000-00-00 00:00:00' for columns `date_created` and `date_modified`.
 	 *
-	 * @since 3.0
+	 * @since 3.0.2
 	 * @return bool
 	 */
-	protected function __202002141() {
+	protected function __202207161() {
 
 		// Update `date_created`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default CURRENT_TIMESTAMP;
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00'
 		" );
 
 		// Update `date_modified`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default CURRENT_TIMESTAMP;
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00'
 		" );
 
-		return $this->is_success( $result );
-
+		return true;
 	}
-
 }

--- a/includes/database/tables/class-order-addresses.php
+++ b/includes/database/tables/class-order-addresses.php
@@ -38,7 +38,7 @@ final class Order_Addresses extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 202002141;
+	protected $version = 202207161;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -50,7 +50,7 @@ final class Order_Addresses extends Table {
 	protected $upgrades = array(
 		'201906251' => 201906251,
 		'201906281' => 201906281,
-		'202002141' => 202002141,
+		'202207161' => 202207161,
 	);
 
 	/**
@@ -72,8 +72,8 @@ final class Order_Addresses extends Table {
 			region mediumtext NOT NULL,
 			postal_code varchar(32) NOT NULL default '',
 			country mediumtext NOT NULL,
-			date_created datetime NOT NULL default CURRENT_TIMESTAMP,
-			date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
+			date_created datetime NOT NULL default '0000-00-00 00:00:00',
+			date_modified datetime NOT NULL default '0000-00-00 00:00:00',
 			uuid varchar(100) NOT NULL default '',
 			PRIMARY KEY (id),
 			KEY order_id (order_id),
@@ -103,7 +103,7 @@ final class Order_Addresses extends Table {
 		// Don't take any action if the column already exists.
 		if ( false === $column_exists ) {
 			$column_exists = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `name` mediumtext NOT NULL AFTER `last_name`;
+				ALTER TABLE {$this->table_name} ADD COLUMN `name` mediumtext NOT NULL AFTER `last_name`
 			" );
 
 		}
@@ -111,12 +111,12 @@ final class Order_Addresses extends Table {
 		$deprecated_columns_exist = ( $this->column_exists( 'first_name' ) && $this->column_exists( 'last_name' ) );
 		if ( $column_exists && $deprecated_columns_exist ) {
 			$data_merged = $this->get_db()->query( "
-					UPDATE {$this->table_name} SET name = CONCAT(first_name, ' ', last_name);
+					UPDATE {$this->table_name} SET name = CONCAT(first_name, ' ', last_name)
 				" );
 
 			if ( $data_merged ) {
 				$success = $this->get_db()->query( "
-					ALTER TABLE {$this->table_name} DROP first_name, DROP last_name;
+					ALTER TABLE {$this->table_name} DROP first_name, DROP last_name
 				" );
 				}
 		}
@@ -149,26 +149,24 @@ final class Order_Addresses extends Table {
 	}
 
 	/**
-	 * Upgrade to version 202002141
-	 *  - Change default value to `CURRENT_TIMESTAMP` for columns `date_created` and `date_modified`.
+	 * Upgrade to version 202207161
+	 *  - Change default value to '0000-00-00 00:00:00' for columns `date_created` and `date_modified`.
 	 *
-	 * @since 3.0
+	 * @since 3.0.2
 	 * @return bool
 	 */
-	protected function __202002141() {
+	protected function __202207161() {
 
 		// Update `date_created`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default CURRENT_TIMESTAMP;
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00'
 		" );
 
 		// Update `date_modified`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default CURRENT_TIMESTAMP;
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00'
 		" );
 
-		return $this->is_success( $result );
-
+		return true;
 	}
-
 }

--- a/includes/database/tables/class-order-adjustments.php
+++ b/includes/database/tables/class-order-adjustments.php
@@ -38,7 +38,7 @@ final class Order_Adjustments extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 202105221;
+	protected $version = 202207161;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,10 +48,10 @@ final class Order_Adjustments extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'202002141' => 202002141,
 		'202011122' => 202011122,
 		'202103151' => 202103151,
 		'202105221' => 202105221,
+		'202207161' => 202207161,
 	);
 
 	/**
@@ -74,36 +74,13 @@ final class Order_Adjustments extends Table {
 		tax decimal(18,9) NOT NULL default '0',
 		total decimal(18,9) NOT NULL default '0',
 		rate decimal(10,5) NOT NULL DEFAULT 1.00000,
-		date_created datetime NOT NULL default CURRENT_TIMESTAMP,
-		date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
+		date_created datetime NOT NULL default '0000-00-00 00:00:00',
+		date_modified datetime NOT NULL default '0000-00-00 00:00:00',
 		uuid varchar(100) NOT NULL default '',
 		PRIMARY KEY (id),
 		KEY object_id_type (object_id,object_type(20)),
 		KEY date_created (date_created),
 		KEY parent (parent)";
-	}
-
-	/**
-	 * Upgrade to version 202002141
-	 *  - Change default value to `CURRENT_TIMESTAMP` for columns `date_created` and `date_modified`.
-	 *
-	 * @since 3.0
-	 * @return bool
-	 */
-	protected function __202002141() {
-
-		// Update `date_created`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default CURRENT_TIMESTAMP;
-		" );
-
-		// Update `date_modified`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default CURRENT_TIMESTAMP;
-		" );
-
-		return $this->is_success( $result );
-
 	}
 
 	/**
@@ -118,14 +95,14 @@ final class Order_Adjustments extends Table {
 
 		// Update `type_id`.
 		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `type_id` bigint(20) default NULL;
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `type_id` bigint(20) default NULL
 		" );
 
 		// Add `type_key`.
 		$column_exists = $this->column_exists( 'type_key' );
 		if ( false === $column_exists ) {
 			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `type_key` varchar(255) default NULL AFTER `type`;
+				ALTER TABLE {$this->table_name} ADD COLUMN `type_key` varchar(255) default NULL AFTER `type`
 			" );
 		} else {
 			$result = $this->get_db()->query( "
@@ -134,7 +111,7 @@ final class Order_Adjustments extends Table {
 		}
 
 		// Change `type_id` with `0` value to `null` to support new default.
-		$this->get_db()->query( "UPDATE {$this->table_name} SET type_id = null WHERE type_id = 0;" );
+		$this->get_db()->query( "UPDATE {$this->table_name} SET type_id = null WHERE type_id = 0" );
 
 		return $this->is_success( $result );
 	}
@@ -148,13 +125,14 @@ final class Order_Adjustments extends Table {
 	 * @return bool
 	 */
 	protected function __202103151() {
+
 		// Look for column
 		$result = $this->column_exists( 'parent' );
 
 		// Maybe add column
 		if ( false === $result ) {
 			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN parent bigint(20) unsigned NOT NULL default '0' AFTER id;
+				ALTER TABLE {$this->table_name} ADD COLUMN parent bigint(20) unsigned NOT NULL default '0' AFTER id
 			" );
 		}
 
@@ -181,6 +159,28 @@ final class Order_Adjustments extends Table {
 				)
 			);
 		}
+
+		return true;
+	}
+
+	/**
+	 * Upgrade to version 202207161
+	 *  - Change default value to '0000-00-00 00:00:00' for columns `date_created` and `date_modified`.
+	 *
+	 * @since 3.0.2
+	 * @return bool
+	 */
+	protected function __202207161() {
+
+		// Update `date_created`.
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00'
+		" );
+
+		// Update `date_modified`.
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00'
+		" );
 
 		return true;
 	}

--- a/includes/database/tables/class-order-items.php
+++ b/includes/database/tables/class-order-items.php
@@ -38,7 +38,7 @@ final class Order_Items extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 202110141;
+	protected $version = 202207161;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -49,11 +49,11 @@ final class Order_Items extends Table {
 	 */
 	protected $upgrades = array(
 		'201906241' => 201906241,
-		'202002141' => 202002141,
 		'202102010' => 202102010,
 		'202103151' => 202103151,
 		'202105221' => 202105221,
 		'202110141' => 202110141,
+		'202207161' => 202207161,
 	);
 
 	/**
@@ -80,8 +80,8 @@ final class Order_Items extends Table {
 			tax decimal(18,9) NOT NULL default '0',
 			total decimal(18,9) NOT NULL default '0',
 			rate decimal(10,5) NOT NULL DEFAULT 1.00000,
-			date_created datetime NOT NULL default CURRENT_TIMESTAMP,
-			date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
+			date_created datetime NOT NULL default '0000-00-00 00:00:00',
+			date_modified datetime NOT NULL default '0000-00-00 00:00:00',
 			uuid varchar(100) NOT NULL default '',
 			PRIMARY KEY (id),
 			KEY order_product_price_id (order_id,product_id,price_id),
@@ -100,34 +100,11 @@ final class Order_Items extends Table {
 	 */
 	protected function __201906241() {
 		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY `quantity` int signed NOT NULL default '0';
+			ALTER TABLE {$this->table_name} MODIFY `quantity` int signed NOT NULL default '0'
 		" );
 
 		// Return success/fail
 		return $this->is_success( $result );
-	}
-
-	/**
-	 * Upgrade to version 202002141
-	 *  - Change default value to `CURRENT_TIMESTAMP` for columns `date_created` and `date_modified`.
-	 *
-	 * @since 3.0
-	 * @return bool
-	 */
-	protected function __202002141() {
-
-		// Update `date_created`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default CURRENT_TIMESTAMP;
-		" );
-
-		// Update `date_modified`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default CURRENT_TIMESTAMP;
-		" );
-
-		return $this->is_success( $result );
-
 	}
 
 	/**
@@ -137,9 +114,10 @@ final class Order_Items extends Table {
 	 * @return bool
 	 */
 	protected function __202102010() {
+
 		// Update `status`.
 		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `status` varchar(20) NOT NULL default 'pending';
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `status` varchar(20) NOT NULL default 'pending'
 		" );
 
 		return $this->is_success( $result );
@@ -154,13 +132,14 @@ final class Order_Items extends Table {
 	 * @return bool
 	 */
 	protected function __202103151() {
+
 		// Look for column
 		$result = $this->column_exists( 'parent' );
 
 		// Maybe add column
 		if ( false === $result ) {
 			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN parent bigint(20) unsigned NOT NULL default '0' AFTER id;
+				ALTER TABLE {$this->table_name} ADD COLUMN parent bigint(20) unsigned NOT NULL default '0' AFTER id
 			" );
 		}
 
@@ -200,10 +179,31 @@ final class Order_Items extends Table {
 	 */
 	protected function __202110141() {
 		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN price_id bigint(20) unsigned default null;
+			ALTER TABLE {$this->table_name} MODIFY COLUMN price_id bigint(20) unsigned default null
 		" );
 
 		return $this->is_success( $result );
 	}
 
+	/**
+	 * Upgrade to version 202207161
+	 *  - Change default value to '0000-00-00 00:00:00' for columns `date_created` and `date_modified`.
+	 *
+	 * @since 3.0.2
+	 * @return bool
+	 */
+	protected function __202207161() {
+
+		// Update `date_created`.
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00'
+		" );
+
+		// Update `date_modified`.
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00'
+		" );
+
+		return true;
+	}
 }

--- a/includes/database/tables/class-order-transactions.php
+++ b/includes/database/tables/class-order-transactions.php
@@ -38,7 +38,7 @@ final class Order_Transactions extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 202205241;
+	protected $version = 202207161;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,10 +48,10 @@ final class Order_Transactions extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'202002141' => 202002141,
 		'202005261' => 202005261,
 		'202105291' => 202105291,
 		'202205241' => 202205241,
+		'202207161' => 202207161,
 	);
 
 	/**
@@ -70,8 +70,8 @@ final class Order_Transactions extends Table {
 			status varchar(20) NOT NULL default '',
 			total decimal(18,9) NOT NULL default '0',
 			rate decimal(10,5) NOT NULL DEFAULT 1.00000,
-			date_created datetime NOT NULL default CURRENT_TIMESTAMP,
-			date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
+			date_created datetime NOT NULL default '0000-00-00 00:00:00',
+			date_modified datetime NOT NULL default '0000-00-00 00:00:00',
 			uuid varchar(100) NOT NULL default '',
 			PRIMARY KEY (id),
 			KEY transaction_id (transaction_id(64)),
@@ -79,29 +79,6 @@ final class Order_Transactions extends Table {
 			KEY status (status(20)),
 			KEY date_created (date_created),
 			KEY object_type_object_id (object_type, object_id)";
-	}
-
-	/**
-	 * Upgrade to version 202002141
-	 *  - Change default value to `CURRENT_TIMESTAMP` for columns `date_created` and `date_modified`.
-	 *
-	 * @since 3.0
-	 * @return bool
-	 */
-	protected function __202002141() {
-
-		// Update `date_created`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default CURRENT_TIMESTAMP;
-		" );
-
-		// Update `date_modified`.
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default CURRENT_TIMESTAMP;
-		" );
-
-		return $this->is_success( $result );
-
 	}
 
 	/**
@@ -116,7 +93,7 @@ final class Order_Transactions extends Table {
 
 		// Increase the transaction_id column.
 		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `transaction_id` varchar(256) NOT NULL default '';
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `transaction_id` varchar(256) NOT NULL default ''
 		" );
 
 		return $this->is_success( $result );
@@ -158,4 +135,25 @@ final class Order_Transactions extends Table {
 		return true;
 	}
 
+	/**
+	 * Upgrade to version 202207161
+	 *  - Change default value to '0000-00-00 00:00:00' for columns `date_created` and `date_modified`.
+	 *
+	 * @since 3.0.2
+	 * @return bool
+	 */
+	protected function __202207161() {
+
+		// Update `date_created`.
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00'
+		" );
+
+		// Update `date_modified`.
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00'
+		" );
+
+		return true;
+	}
 }


### PR DESCRIPTION
Re-adds support for older versions of MySQL.

Proposed Changes:
1. Remove `CURRENT_TIMESTAMP`
2. Use `0000-00-00 00:00:00` again
3. Remove some now-irrelevant upgrade routines & queries
4. Bumps table versions
5. Modifies CREATE TABLE queries and default column values in Schemas