### PR TITLE
Update data check for migration

### DIFF
--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -205,9 +205,9 @@ function edd_show_upgrade_notices() {
 		if ( ! edd_v30_is_migration_complete() ) {
 
 			// The final EDD Payment ID was recorded when the orders table was created.
-			$has_orders = _edd_get_final_payment_id();
+			$needs_migration = _edd_needs_v3_migration();
 
-			if ( $has_orders ) {
+			if ( $needs_migration ) {
 				?>
 				<div class="updated">
 					<?php if ( get_option( 'edd_v30_cli_migration_running' ) ) { ?>

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1851,6 +1851,8 @@ function _edd_get_final_payment_id() {
  * Evaluates whether the EDD 3.0 migration should be run,
  * based on _any_ data existing which will need to be migrated.
  *
+ * This should only be run after `edd_v30_is_migration_complete` has returned false.
+ *
  * @todo deprecate in 3.1
  *
  * @since 3.0.2

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1848,6 +1848,104 @@ function _edd_get_final_payment_id() {
 }
 
 /**
+ * Evaluates whether the EDD 3.0 migration should be run,
+ * based on _any_ data existing which will need to be migrated.
+ *
+ * @todo deprecate in 3.1
+ *
+ * @since 3.0.2
+ * @return bool
+ */
+function _edd_needs_v3_migration() {
+	// Return true if a final payment ID was recorded.
+	if ( _edd_get_final_payment_id() ) {
+		return true;
+	}
+
+	// Return true if any tax rates were saved.
+	$tax_rates = get_option( 'edd_tax_rates', array() );
+	if ( ! empty( $tax_rates ) ) {
+		return true;
+	}
+
+	global $wpdb;
+
+	// Return true if any discounts were saved.
+	$discounts = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT *
+			 FROM {$wpdb->posts}
+			 WHERE post_type = %s
+			 LIMIT 1",
+			esc_sql( 'edd_discount' )
+		)
+	);
+	if ( ! empty( $discounts ) ) {
+		return true;
+	}
+
+	// Return true if there are any customers.
+	$customers = $wpdb->get_results(
+		"SELECT *
+		FROM {$wpdb->edd_customers}
+		LIMIT 1"
+	);
+	if ( ! empty( $customers ) ) {
+		return true;
+	}
+
+	// Return true if any customer email addresses were saved.
+	$customer_emails = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT *
+			 FROM {$wpdb->edd_customermeta}
+			 WHERE meta_key = %s
+			 LIMIT 1",
+			esc_sql( 'additional_email' )
+		)
+	);
+	if ( ! empty( $customer_emails ) ) {
+		return true;
+	}
+
+	// Return true if any customer addresses are in the user meta table.
+	$customer_addresses = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT *
+			 FROM {$wpdb->usermeta}
+			 WHERE meta_key = %s
+			 ORDER BY umeta_id ASC
+			 LIMIT 1",
+			esc_sql( '_edd_user_address' )
+		)
+	);
+	if ( ! empty( $customer_addresses ) ) {
+		return true;
+	}
+
+	// Return true if there are any EDD logs (not sales) saved.
+	$logs = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT p.*, t.slug
+			 FROM {$wpdb->posts} AS p
+			 LEFT JOIN {$wpdb->term_relationships} AS tr ON (p.ID = tr.object_id)
+			 LEFT JOIN {$wpdb->term_taxonomy} AS tt ON (tr.term_taxonomy_id = tt.term_taxonomy_id)
+			 LEFT JOIN {$wpdb->terms} AS t ON (tt.term_id = t.term_id)
+			 WHERE p.post_type = %s AND t.slug != %s
+			 GROUP BY p.ID
+			 LIMIT 1",
+			esc_sql( 'edd_log' ),
+			esc_sql( 'sale' )
+		)
+	);
+	if ( ! empty( $logs ) ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * Maybe adds a migration in progress notice to the order history.
  *
  * @todo remove in 3.1

--- a/tests/tests-migration.php
+++ b/tests/tests-migration.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Migration tests.
+ */
+class Migration_Tests extends \EDD_UnitTestCase {
+	public function test_edd_needs_v3_migration_no_data_should_return_false() {
+		$this->assertFalse( _edd_needs_v3_migration() );
+	}
+
+	public function test_edd_needs_v3_migration_final_payment_should_return_true() {
+		update_option( 'edd_v3_migration_pending', 123456, false );
+
+		$this->assertTrue( _edd_needs_v3_migration() );
+		delete_option( 'edd_v3_migration_pending' );
+	}
+
+	public function test_edd_needs_v3_migration_discount_should_return_true() {
+		$discount_id = wp_insert_post(
+			array(
+				'post_type'   => 'edd_discount',
+				'post_title'  => 'Legacy Discount',
+				'post_status' => 'active',
+			)
+		);
+
+		$this->assertTrue( _edd_needs_v3_migration() );
+		wp_delete_post( $discount_id );
+	}
+
+	public function test_edd_needs_v3_migration_user_address_should_return_true() {
+		$this->setExpectedIncorrectUsage( 'add_user_meta()/update_user_meta()' );
+		$user_id = wp_create_user(
+			'test_migration_user',
+			'password'
+		);
+		$address = add_metadata(
+			'user',
+			$user_id,
+			'_edd_user_address',
+			array(
+				'line1'   => 'First address',
+				'line2'   => 'Line two',
+				'city'    => 'MyCity',
+				'zip'     => '12345',
+				'country' => 'US',
+				'state'   => 'AL',
+			)
+		);
+
+		$this->assertTrue( _edd_needs_v3_migration() );
+		wp_delete_user( $user_id );
+	}
+
+	public function test_edd_needs_v3_migration_tax_rates_should_return_true() {
+		$tax_rates = array(
+			array(
+				'country' => 'US',
+				'state'   => 'AL',
+				'rate'    => 15,
+			),
+		);
+		update_option( 'edd_tax_rates', $tax_rates );
+
+		$this->assertTrue( _edd_needs_v3_migration() );
+		delete_option( 'edd_tax_rates' );
+	}
+}


### PR DESCRIPTION
Fixes #9295

Proposed Changes:
1. Creates the `_edd_needs_v3_migration` function, which returns a boolean based on multiple checks. Any `true` check short circuits the rest of the checks, so (for example) if any payments were detected, then no other checks will return true.
2. Subsequent checks are ordered by "weight", roughly, with the most expensive (logs) being last. All queries are pulled from the comparable class in the v3 folder, just updated to check for one item only.
3. New checks include:
    - Any tax rates
    - Discounts
    - Any customers
    - Any customer emails (this likely won't trigger if the previous one didn't)
    - Any customer physical addresses (stored in user meta)
    - Any non-sales logs
4. Adds unit tests to selectively add/remove old sample data and make sure that the check returns true.
