### PR TITLE
Fixed wrong capability check when adding manual order note

### DIFF
--- a/includes/admin/notes/note-actions.php
+++ b/includes/admin/notes/note-actions.php
@@ -23,7 +23,7 @@ function edd_admin_ajax_add_note() {
 	check_ajax_referer( 'edd_note', 'nonce' );
 
 	// Bail if user cannot delete notes
-	if ( ! current_user_can( 'manage_shop_settings' ) ) {
+	if ( ! current_user_can( 'edit_shop_payments' ) ) {
 		wp_die( -1 );
 	}
 

--- a/includes/admin/notes/note-functions.php
+++ b/includes/admin/notes/note-functions.php
@@ -125,6 +125,10 @@ function edd_admin_get_note_html( $note_id = 0 ) {
  */
 function edd_admin_get_new_note_form( $object_id = 0, $object_type = '' ) {
 
+	if ( ! current_user_can( 'edit_shop_payments' ) ) {
+		return;
+	}
+
 	// Start a buffer
 	ob_start();?>
 

--- a/includes/admin/notes/note-functions.php
+++ b/includes/admin/notes/note-functions.php
@@ -126,7 +126,7 @@ function edd_admin_get_note_html( $note_id = 0 ) {
 function edd_admin_get_new_note_form( $object_id = 0, $object_type = '' ) {
 
 	if ( ! current_user_can( 'edit_shop_payments' ) ) {
-		return;
+		return '';
 	}
 
 	// Start a buffer


### PR DESCRIPTION
Fixes #9293

Proposed Changes:
- We should allow adding notes for a role that can`edit_shop_payments`. If a role is allowed to edit payments, they should be allowed to add notes.