### PR TITLE
Fix Swedish postal code validation and add unit tests around just SE postal codes #9302

### DIFF
--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -1198,7 +1198,7 @@ function edd_purchase_form_validate_cc_zip( $zip = 0, $country_code = '' ) {
 		"RS" => "\d{5}",
 		"RU" => "\d{6}",
 		"SA" => "\d{5}",
-		"SE" => "^(s-|S-) {0,1}[0-9]{3}\s?[0-9]{2}$",
+		"SE" => "^(s-|S-){0,1}[0-9]{3}\s?[0-9]{2}$",
 		"SG" => "\d{6}",
 		"SH" => "(ASCN|STHL) 1ZZ",
 		"SI" => "\d{4}",

--- a/tests/tests-misc.php
+++ b/tests/tests-misc.php
@@ -910,6 +910,18 @@ class Test_Misc extends EDD_UnitTestCase {
 		$this->assertTrue( function_exists( 'is_iterable' ) );
 	}
 
+	function test_postal_codes_SE_leading_s() {
+		$this->assertTrue( edd_purchase_form_validate_cc_zip( 's-12345', 'SE' ) );
+	}
+
+	function test_postal_codes_SE_leading_capital_s() {
+		$this->assertTrue( edd_purchase_form_validate_cc_zip( 'S-12345', 'SE' ) );
+	}
+
+	function test_postal_codes_SE_numeric() {
+		$this->assertTrue( edd_purchase_form_validate_cc_zip( '12345', 'SE' ) );
+	}
+
 	private function write_test_file( $full_file_path ) {
 		$file = fopen( $full_file_path,"w" );
 		fwrite( $file,"" );


### PR DESCRIPTION
Fixes #9302 

Proposed Changes:
1. Adjusts the RegEx to accept prefixed and non-prefixed postal codes for Sweden.
2. Adds unit test around all 3 cases.