### PR TITLE
Remove extra escaping from user verification URL

### DIFF
--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -1160,14 +1160,12 @@ function edd_verify_customer_notice( $customer ) {
 	}
 
 	$url = wp_nonce_url(
-		esc_url(
-			edd_get_admin_url(
-				array(
-					'page'       => 'edd-customers',
-					'view'       => 'overview',
-					'edd_action' => 'verify_user_admin',
-					'id'         => absint( $customer->id ),
-				)
+		edd_get_admin_url(
+			array(
+				'page'       => 'edd-customers',
+				'view'       => 'overview',
+				'edd_action' => 'verify_user_admin',
+				'id'         => absint( $customer->id ),
 			)
 		),
 		'edd-verify-user'


### PR DESCRIPTION
Fixes #9307

Proposed Changes:
1. The user verification URL was being escaped twice and breaking the URL. This removes the extra escaping so it's just escaped when echoed.