### PR TITLE
Decrease discount usage count when order is deleted

### DIFF
--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -277,6 +277,10 @@ function edd_destroy_order( $order_id = 0 ) {
 		// Destroy adjustments.
 		if ( ! empty( $adjustments ) ) {
 			foreach ( $adjustments as $adjustment ) {
+				// Decrease adjustment coupon use count.
+				if ( 'discount' === $adjustment->type ) {
+					edd_decrease_discount_usage( $adjustment->description );
+				}
 				edd_delete_order_adjustment( $adjustment->id );
 			}
 		}

--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -277,7 +277,7 @@ function edd_destroy_order( $order_id = 0 ) {
 		// Destroy adjustments.
 		if ( ! empty( $adjustments ) ) {
 			foreach ( $adjustments as $adjustment ) {
-				// Decrease adjustment coupon use count.
+				// Decrease discount code use count.
 				if ( 'discount' === $adjustment->type ) {
 					edd_decrease_discount_usage( $adjustment->description );
 				}


### PR DESCRIPTION
Fixes #9299

Proposed Changes:
- Made changes into `edd_destroy_order` method where I loop through order adjustments, detect if adjustment is the discount, and then call the use count decrease method