### PR TITLE
Change the upgrade message if the orders table could not be created

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -177,7 +177,7 @@ final class EDD_Requirements_Check {
 	 * @return string
 	 */
 	private function unmet_requirements_url() {
-		return 'https://docs.easydigitaldownloads.com/article/2051-minimum-requirements-for-edd-3-0';
+		return 'https://easydigitaldownloads.com/recommended-wordpress-hosting/';
 	}
 
 	/**

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -206,8 +206,9 @@ function edd_show_upgrade_notices() {
 
 			// The final EDD Payment ID was recorded when the orders table was created.
 			$needs_migration = _edd_needs_v3_migration();
+			global $wpdb;
 
-			if ( $needs_migration ) {
+			if ( $needs_migration && ! empty( $wpdb->edd_orders ) ) {
 				?>
 				<div class="updated">
 					<?php if ( get_option( 'edd_v30_cli_migration_running' ) ) { ?>
@@ -279,6 +280,32 @@ function edd_show_upgrade_notices() {
 						<?php
 					}
 					?>
+				</div>
+				<?php
+			} else {
+
+				// The orders database table is missing (we assume all primary tables have failed to create).
+				$message          = __( 'Easy Digital Downloads was unable to create the necessary database tables. Your site may not meet the minimum requirements for EDD 3.0.', 'easy-digital-downloads' );
+				$database_version = $wpdb->db_version();
+
+				// The database version is the problem.
+				if ( version_compare( $database_version, '5.6', '<' ) ) {
+					$message .= ' ' . sprintf(
+						/* translators: MySQL database version, do not translate */
+						__( 'Please contact your host and ask them to upgrade your MySQL version (your current version is %s).', 'easy-digital-downloads' ),
+						$database_version
+					);
+				} else {
+					$message .= ' ' . sprintf(
+						/* translators: 1. opening anchor tag, do not translate; 2. closing anchor tag, do not translate */
+						__( '%1$sContact our support team%2$s for help with next steps.', 'easy-digital-downloads' ),
+						'<a href="https://easydigitaldownloads.com/support/">',
+						'</a>'
+					);
+				}
+				?>
+				<div class="notice notice-error">
+					<p><?php echo wp_kses_post( $message ); ?></p>
 				</div>
 				<?php
 			}

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -285,7 +285,7 @@ function edd_show_upgrade_notices() {
 			} else {
 
 				// The orders database table is missing (we assume all primary tables have failed to create).
-				$message          = __( 'Easy Digital Downloads was unable to create the necessary database tables. Your site may not meet the minimum requirements for EDD 3.0.', 'easy-digital-downloads' );
+				$message          = __( 'Easy Digital Downloads was unable to create the necessary database tables to complete this update. Your site may not meet the minimum requirements for EDD 3.0.', 'easy-digital-downloads' );
 				$database_version = $wpdb->db_version();
 
 				// The database version is the problem.

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -291,8 +291,10 @@ function edd_show_upgrade_notices() {
 				// The database version is the problem.
 				if ( version_compare( $database_version, '5.6', '<' ) ) {
 					$message .= ' ' . sprintf(
-						/* translators: MySQL database version, do not translate */
-						__( 'Please contact your host and ask them to upgrade your MySQL version (your current version is %s).', 'easy-digital-downloads' ),
+						/* translators: 1. opening anchor tag, do not translate; 2. closing anchor tag, do not translate; 3. MySQL database version, do not translate */
+						__( 'Please contact your host and ask them to upgrade your environment to meet our %1$sminimum technical requirements%2$s. Your MySQL version is %3$s and needs to be updated.', 'easy-digital-downloads' ),
+						'<a href="https://easydigitaldownloads.com/recommended-wordpress-hosting/">',
+						'</a>',
 						$database_version
 					);
 				} else {


### PR DESCRIPTION
This adds an additional check to the 3.0 upgrade notice, checking for the orders table. If it was not created, an error notice is displayed instead of the upgrade notice. The error shows one of two messages:
1. If the database version doesn't meet the minimum 5.6 they're instructed to contact their host for help with upgrading that.
2. If the database version did meet the minimum then they're instructed to contact our support instead.