### PR TITLE
Add edd_record_download_log_args filter

### DIFF
--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -817,7 +817,7 @@ function edd_record_download_in_log( $download_id = 0, $file_id = 0, $user_info 
 		'customer_id' => $order->customer_id,
 		'ip'          => sanitize_text_field( $ip ),
 		'user_agent'  => $user_agent,
-	), $user_info );
+	) );
 
 	edd_add_file_download_log( $args );
 }


### PR DESCRIPTION
Fixes #

Proposed Changes:
1. Introduced a new edd_record_download_log_args filter to allow short-circuiting of the record log.
2. Validate the order exists before proceeding, since a relationship is (technically) required for the customer ID property.
