### PR TITLE
Update table check for upgrade notice

### DIFF
--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -206,9 +206,14 @@ function edd_show_upgrade_notices() {
 
 			// The final EDD Payment ID was recorded when the orders table was created.
 			$needs_migration = _edd_needs_v3_migration();
-			global $wpdb;
+			$version         = false;
+			$component       = edd_get_component( 'order' );
+			$table           = $component->get_interface( 'table' );
+			if ( ! empty( $table ) ) {
+				$version = $table->get_version();
+			}
 
-			if ( $needs_migration && ! empty( $wpdb->edd_orders ) ) {
+			if ( $needs_migration && $version ) {
 				?>
 				<div class="updated">
 					<?php if ( get_option( 'edd_v30_cli_migration_running' ) ) { ?>

--- a/includes/install.php
+++ b/includes/install.php
@@ -252,7 +252,7 @@ function edd_run_install( $site_id = false ) {
 function edd_set_all_upgrades_complete() {
 
 	// Bail if not a fresh installation
-	if ( ! edd_get_db_version() ) {
+	if ( edd_get_db_version() ) {
 		return;
 	}
 

--- a/includes/install.php
+++ b/includes/install.php
@@ -269,6 +269,8 @@ function edd_set_all_upgrades_complete() {
 		'remove_refunded_sale_logs',
 		'update_file_download_log_data',
 	);
+	$edd_30_upgrades  = edd_get_v30_upgrades();
+	$upgrade_routines = array_merge( $upgrade_routines, array_keys( $edd_30_upgrades ) );
 
 	// Loop through upgrade routines and mark them as complete
 	foreach ( $upgrade_routines as $upgrade ) {

--- a/tests/tests-install.php
+++ b/tests/tests-install.php
@@ -85,6 +85,14 @@ class Tests_Activation extends EDD_UnitTestCase {
 
 	}
 
+	public function test_edd_upgrades_have_completed_upgrade_payment_taxes_is_true() {
+		$this->assertTrue( edd_has_upgrade_completed( 'upgrade_payment_taxes' ) );
+	}
+
+	public function test_edd_upgrades_have_completed_migrate_orders_is_true() {
+		$this->assertTrue( edd_has_upgrade_completed( 'migrate_orders' ) );
+	}
+
 	/**
 	 * Test that the install doesn't redirect when activating multiple plugins.
 	 *


### PR DESCRIPTION
Proposed Changes:
Instead of checking the `$wpdb` global for the orders table, this uses the `edd_get_component` function to get the Order component, then the database table, and then the version. If the version is retrieved we can proceed with the upgrade.