### PR TITLE
Fixed "Total refund amount" relative data percentage calculation

### DIFF
--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -704,7 +704,7 @@ class Stats {
 
 		if ( true === $this->query_vars['relative'] ) {
 			$total    = -( floatval( $initial_result->total ) );
-			$relative = floatval( $relative_result->total );
+			$relative = -( floatval( $relative_result->total ) );
 			$total    = $this->generate_relative_markup( $total, $relative, true );
 		} else {
 			$total = $this->maybe_format( -( $total ) );


### PR DESCRIPTION
Fixes #9325

Proposed Changes:
- Very small calculation change inside `get_order_refund_amount` method. Relative data was a positive number, while total data was negative, therefore causing the wrong percentage change calculation

