### PR TITLE
Show any edd_template files copied to the theme for possible customization #7827

### DIFF
--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -1317,6 +1317,21 @@ function edd_tools_sysinfo_get() {
 	if ( $parent_theme !== $theme ) {
 		$return .= 'Parent Theme:             ' . $parent_theme . "\n";
 	}
+
+	$customized_template_files = edd_get_theme_edd_templates();
+	$return .= "\n" . '-- Customized Templates' . "\n\n";
+	if ( empty( $customized_template_files ) ) {
+		$return .= 'No custom templates found.' . "\n\n";
+	} else {
+		foreach ( $customized_template_files as $customized_template_file ) {
+			$return .= $customized_template_file . "\n";
+		}
+	}
+
+	$return .= "\n";
+
+	$return = apply_filters( 'edd_sysinfo_after_customized_templates', $return );
+
 	$return .= 'Show On Front:            ' . get_option( 'show_on_front' ) . "\n";
 
 	// Only show page specs if frontpage is set to 'page'

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -1172,3 +1172,43 @@ function edd_pagination( $args = array() ) {
 		</div>
 	<?php endif;
 }
+
+/**
+ * Return a list of theme files found in both parent and child themes.
+ *
+ * This allows us to detect when a core template is being overridden by a theme.
+ *
+ * @since 3.1
+ *
+ * @return array List of files that the parent and child themes are overriding, relative.
+ */
+function edd_get_theme_edd_templates() {
+	$parent_theme_dir = trailingslashit( get_template_directory() ) . 'edd_templates/';
+	$child_theme_dir  = trailingslashit( get_stylesheet_directory() ) . 'edd_templates/';
+
+	$theme_edd_templates = array();
+
+	if ( $parent_theme_dir === $child_theme_dir ) {
+		$child_theme_dir = false;
+	}
+
+	$found_templates = array();
+	if ( is_dir( $parent_theme_dir ) ) {
+		$found_templates = list_files( $parent_theme_dir );
+	}
+
+	$found_child_templates = array();
+	if ( false !== $child_theme_dir && is_dir( $child_theme_dir ) ) {
+		$found_child_templates = list_files( $child_theme_dir );
+	}
+
+	$theme_edd_templates = array_map(
+		function( $file ) {
+			return str_replace( get_theme_root() . '/', '', $file );
+		},
+		array_merge( $found_templates, $found_child_templates )
+	);
+
+	return $theme_edd_templates;
+}
+add_action( 'admin_init', 'edd_get_theme_edd_templates' );

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -1211,4 +1211,3 @@ function edd_get_theme_edd_templates() {
 
 	return $theme_edd_templates;
 }
-add_action( 'admin_init', 'edd_get_theme_edd_templates' );


### PR DESCRIPTION
Fixes #7827 

Proposed Changes:
1. Adds new `edd_get_theme_edd_templates` function, that finds any directories and files in the parent and child theme that are in the `edd_templates` directory and returns them as an array.
2. Adds the results of `edd_get_theme_edd_templates` to the system info.