### PR TITLE
Update price ID checks for reports

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -407,7 +407,7 @@ function edd_register_downloads_report( $reports ) {
 		if ( $download_data ) {
 			$download = edd_get_download( $download_data['download_id'] );
 			$prices   = $download->get_prices();
-			if ( $download_data['price_id'] ) {
+			if ( isset( $download_data['price_id'] ) && is_numeric( $download_data['price_id'] ) ) {
 				$args       = array( 'price_id' => $download_data['price_id'] );
 				$price_name = edd_get_price_name( $download->ID, $args );
 				if ( $price_name ) {
@@ -716,7 +716,7 @@ function edd_register_downloads_report( $reports ) {
 							);
 						}
 
-						$price_id = ! empty( $download_data['price_id'] )
+						$price_id = isset( $download_data['price_id'] ) && is_numeric( $download_data['price_id'] )
 							? $wpdb->prepare( 'AND price_id = %d', absint( $download_data['price_id'] ) )
 							: '';
 
@@ -1516,7 +1516,7 @@ function edd_register_taxes_report( $reports ) {
 		$download_label = '';
 		if ( $download_data ) {
 			$download = edd_get_download( $download_data['download_id'] );
-			if ( $download_data['price_id'] ) {
+			if ( isset( $download_data['price_id'] ) && is_numeric( $download_data['price_id'] ) ) {
 				$args       = array( 'price_id' => $download_data['price_id'] );
 				$price_name = edd_get_price_name( $download->ID, $args );
 				if ( $price_name ) {
@@ -1658,7 +1658,7 @@ function edd_register_file_downloads_report( $reports ) {
 		$download_label = '';
 		if ( $download_data ) {
 			$download = edd_get_download( $download_data['download_id'] );
-			if ( $download_data['price_id'] ) {
+			if ( isset( $download_data['price_id'] ) && is_numeric( $download_data['price_id'] ) ) {
 				$args       = array( 'price_id' => $download_data['price_id'] );
 				$price_name = edd_get_price_name( $download->ID, $args );
 				if ( $price_name ) {
@@ -1833,7 +1833,7 @@ function edd_register_file_downloads_report( $reports ) {
 						if ( is_array( $download_data ) ) {
 							$product_id = $wpdb->prepare( 'AND product_id = %d', absint( $download_data['download_id'] ) );
 
-							$price_id = ! empty( $download_data['price_id'] )
+							$price_id = isset( $download_data['price_id'] ) && is_numeric( $download_data['price_id'] )
 								? $wpdb->prepare( 'AND price_id = %d', absint( $download_data['price_id'] ) )
 								: '';
 						}

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -535,9 +535,10 @@ function edd_register_downloads_report( $reports ) {
 			'views' => array(
 				'tile' => array(
 					'data_callback' => function () use ( $download_data, $dates, $currency ) {
-						$stats = new EDD\Stats( array(
+						$price_id = isset( $download_data['price_id'] ) && is_numeric( $download_data['price_id'] ) ? absint( $download_data['price_id'] ) : null;
+						$stats    = new EDD\Stats( array(
 							'product_id' => absint( $download_data['download_id'] ),
-							'price_id'   => absint( $download_data['price_id'] ),
+							'price_id'   => $price_id,
 							'currency'   => $currency,
 							'range'      => $dates['range'],
 							'output'     => 'formatted',

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -280,7 +280,16 @@ function edd_register_overview_report( $reports ) {
 			'views' => array(
 				'tile' => array(
 					'data_callback' => function () use ( $dates, $exclude_taxes, $currency ) {
-						$stats = new EDD\Stats();
+						$stats = new EDD\Stats(
+							array(
+								'function'      => 'AVG',
+								'output'        => 'formatted',
+								'relative'      => true,
+								'range'         => $dates['range'],
+								'exclude_taxes' => $exclude_taxes,
+								'currency'      => $currency,
+							)
+						);
 						return $stats->get_order_earnings();
 					},
 					'display_args'  => array(

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -233,13 +233,15 @@ function edd_register_overview_report( $reports ) {
 			'views' => array(
 				'tile' => array(
 					'data_callback' => function () use ( $dates, $currency ) {
-						$stats = new EDD\Stats();
-						return $stats->get_order_count( array(
-							'range'        => $dates['range'],
-							'relative'     => true,
-							'currency'     => $currency,
-							'revenue_type' => 'net',
-						) );
+						$stats = new EDD\Stats(
+							array(
+								'range'        => $dates['range'],
+								'relative'     => true,
+								'currency'     => $currency,
+								'revenue_type' => 'net',
+							)
+						);
+						return $stats->get_order_count();
 					},
 					'display_args'  => array(
 						'comparison_label' => $label . ' &mdash; ' . __( 'Net', 'easy-digital-downloads' ),
@@ -253,16 +255,18 @@ function edd_register_overview_report( $reports ) {
 			'views' => array(
 				'tile' => array(
 					'data_callback' => function () use ( $dates, $exclude_taxes, $currency ) {
-						$stats = new EDD\Stats();
-						return $stats->get_order_earnings( array(
-							'range'         => $dates['range'],
-							'function'      => 'SUM',
-							'exclude_taxes' => $exclude_taxes,
-							'currency'      => $currency,
-							'relative'      => true,
-							'output'        => 'formatted',
-							'revenue_type'  => 'net',
-						) );
+						$stats = new EDD\Stats(
+							array(
+								'range'         => $dates['range'],
+								'function'      => 'SUM',
+								'exclude_taxes' => $exclude_taxes,
+								'currency'      => $currency,
+								'relative'      => true,
+								'output'        => 'formatted',
+								'revenue_type'  => 'net',
+							)
+						);
+						return $stats->get_order_earnings();
 					},
 					'display_args'  => array(
 						'comparison_label' => $label . ' &mdash; ' . __( 'Net', 'easy-digital-downloads' ),
@@ -277,14 +281,7 @@ function edd_register_overview_report( $reports ) {
 				'tile' => array(
 					'data_callback' => function () use ( $dates, $exclude_taxes, $currency ) {
 						$stats = new EDD\Stats();
-						return $stats->get_order_earnings( array(
-							'function'      => 'AVG',
-							'output'        => 'formatted',
-							'relative'      => true,
-							'range'         => $dates['range'],
-							'exclude_taxes' => $exclude_taxes,
-							'currency'      => $currency,
-						) );
+						return $stats->get_order_earnings();
 					},
 					'display_args'  => array(
 						'comparison_label' => $label,


### PR DESCRIPTION
Fixes #9337

Proposed Changes:
1. Updates the price ID checks for reporting queries.
2. Updates the sales/earnings overview tiles to set up the parameters when the class is instantiated rather than when calling the individual method.