### PR TITLE
Update the initial checks for the customer database upgrades

### DIFF
--- a/includes/database/tables/class-customer-meta.php
+++ b/includes/database/tables/class-customer-meta.php
@@ -82,17 +82,29 @@ final class Customer_Meta extends Table {
 	 * @since 3.0
 	 */
 	public function maybe_upgrade() {
-		if ( false !== get_option( $this->table_prefix . 'edd_customermeta_db_version', false ) ) {
-			delete_option( $this->table_prefix . 'edd_customermeta_db_version' );
 
-			if ( $this->column_exists( 'customer_id' ) && ! $this->column_exists( 'edd_customer_id' ) ) {
-				$this->get_db()->query( "ALTER TABLE {$this->table_name} CHANGE `customer_id` `edd_customer_id` bigint(20) unsigned NOT NULL default '0';" );
-				$this->get_db()->query( "ALTER TABLE {$this->table_name} DROP INDEX customer_id" );
-				$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX edd_customer_id (edd_customer_id)" );
-			}
+		if ( $this->needs_initial_upgrade() ) {
+
+			// Delete old/irrelevant database options.
+			delete_option( $this->table_prefix . 'edd_customermeta_db_version' );
+			delete_option( 'wp_edd_customermeta_db_version' );
+
+			$this->get_db()->query( "ALTER TABLE {$this->table_name} CHANGE `customer_id` `edd_customer_id` bigint(20) unsigned NOT NULL default '0';" );
+			$this->get_db()->query( "ALTER TABLE {$this->table_name} DROP INDEX customer_id" );
+			$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX edd_customer_id (edd_customer_id)" );
 		}
 
 		parent::maybe_upgrade();
+	}
+
+	/**
+	 * Whether the initial upgrade from the 1.0 database needs to be run.
+	 *
+	 * @since 3.0.3
+	 * @return bool
+	 */
+	private function needs_initial_upgrade() {
+		return $this->column_exists( 'customer_id' ) && ! $this->column_exists( 'edd_customer_id' );
 	}
 
 	/**

--- a/includes/database/tables/class-customers.php
+++ b/includes/database/tables/class-customers.php
@@ -90,8 +90,13 @@ final class Customers extends Table {
 	 * @since 3.0
 	 */
 	public function maybe_upgrade() {
-		if ( false !== get_option( $this->table_prefix . 'edd_customers_db_version', false ) ) {
+
+		if ( $this->needs_initial_upgrade() ) {
+
+			// Delete old/irrelevant database options.
 			delete_option( $this->table_prefix . 'edd_customers_db_version' );
+			delete_option( 'wp_edd_customers_db_version' );
+
 
 			// Modify existing columns.
 			$this->get_db()->query( "ALTER TABLE {$this->table_name} MODIFY `email` varchar(100) NOT NULL default ''" );
@@ -118,6 +123,16 @@ final class Customers extends Table {
 		}
 
 		parent::maybe_upgrade();
+	}
+
+	/**
+	 * Whether the initial upgrade from the 1.0 database needs to be run.
+	 *
+	 * @since 3.0.3
+	 * @return bool
+	 */
+	private function needs_initial_upgrade() {
+		return ! $this->column_exists( 'status' ) && ! $this->column_exists( 'uuid' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #9341

Proposed Changes:
1. Creates a private `needs_initial_upgrade` method for both the customers table and the customer meta table to check the tables directly.
2. Runs an additional `delete_option` for the most likely "missing" option but I'm not sure this is necessary--would be nice to have things tidy but it's also two rows.
