### PR TITLE
Fixed undefined variable in certain cases for reports

### DIFF
--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -730,6 +730,8 @@ function get_dates_filter_range() {
  * @return bool True if results should use hour by hour, otherwise false.
  */
 function get_dates_filter_hour_by_hour() {
+	$hour_by_hour = false;
+
 	// Retrieve the queried dates
 	$dates = get_dates_filter( 'objects' );
 


### PR DESCRIPTION
Fixes #9351

Proposed Changes:
I made sure that `hour_by_hour` variable is defined upfront to avoid cases where it could be undefined.
