### PR TITLE
Update Stats API Endpoint to use proper stats class and date adjustments #9361

### DIFF
--- a/includes/admin/tools/class-edd-tools-recount-store-earnings.php
+++ b/includes/admin/tools/class-edd-tools-recount-store-earnings.php
@@ -93,7 +93,7 @@ class EDD_Tools_Recount_Store_Earnings extends EDD_Batch_Export {
 
 		}
 
-		update_option( 'edd_earnings_total', $total );
+		update_option( 'edd_earnings_total', $total, false );
 		set_transient( 'edd_earnings_total', $total, 86400 );
 
 		return false;

--- a/includes/admin/tools/class-edd-tools-reset-stats.php
+++ b/includes/admin/tools/class-edd-tools-reset-stats.php
@@ -127,8 +127,10 @@ class EDD_Tools_Reset_Stats extends EDD_Batch_Export {
 			$this->done = false;
 			return true;
 		} else {
-			update_option( 'edd_earnings_total', 0 );
+			update_option( 'edd_earnings_total', 0, false );
+			update_option( 'edd_earnings_total_without_tax', 0, false );
 			delete_transient( 'edd_earnings_total' );
+			delete_transient( 'edd_earnings_total_without_tax' );
 			delete_transient( 'edd_estimated_monthly_stats' . true );
 			delete_transient( 'edd_estimated_monthly_stats' . false );
 			$this->delete_data( 'edd_reset_tables_to_truncate' );

--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -13,10 +13,14 @@
  * @copyright   Copyright (c) 2018, Easy Digital Downloads, LLC
  * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since       1.5
+ * @since       3.0.4 Refactored to use the new stats API, returns same formatting as 2.x API.
  */
 
 // Exit if accessed directly
 defined( 'ABSPATH' ) || exit;
+
+use EDD\Reports;
+use EDD\Stats;
 
 /**
  * EDD_API Class
@@ -156,7 +160,6 @@ class EDD_API {
 
 		// Setup EDD_Stats instance
 		$this->stats = new EDD_Payment_Stats;
-
 	}
 
 	/**
@@ -1245,17 +1248,33 @@ class EDD_API {
 					$start_date = $dates['year'] . '-' . $dates['m_start'] . '-' . $dates['day_start'];
 					$end_date   = $dates['year_end'] . '-' . $dates['m_end'] . '-' . $dates['day_end'];
 
-					$stats = EDD()->payment_stats->get_sales_by_range( 'other', true, $start_date, $end_date );
+					// Force the data for the reports API.
+					$_GET['filter_from'] = $start_date;
+					$_GET['filter_to']   = $end_date;
+					$_GET['range']       = 'other';
 
-					foreach ( $stats as $sale ) {
-						$key                    = $sale['y'] . $sale['m'] . $sale['d'];
-						$sales['sales'][ $key ] = (int) $sale['count'];
-					}
+					$stats   = new EDD\Stats();
+					$dates   = EDD\Reports\parse_dates_for_range();
 
-					$start_date = date( 'Y-m-d', strtotime( $start_date ) );
-					$end_date   = date( 'Y-m-d', strtotime( $end_date ) );
+					$total_sales = $stats->get_order_count(
+						array(
+							'start'        => $dates['start']->format( 'Y-m-d H:i:s' ),
+							'end'          => $dates['end']->format( 'Y-m-d H:i:s' ),
+							'revenue_type' => 'net',
+						)
+					);
+					$start_date  = date( 'Y-m-d', strtotime( $start_date ) );
+					$end_date    = date( 'Y-m-d', strtotime( $end_date ) );
 
 					while ( strtotime( $start_date ) <= strtotime( $end_date ) ) {
+
+						// Force the data for the reports API.
+						$_GET['filter_from'] = $start_date;
+						$_GET['filter_to']   = $start_date;
+						$_GET['range']       = 'other';
+
+						$dates = EDD\Reports\parse_dates_for_range();
+
 						$d = date( 'd', strtotime( $start_date ) );
 						$m = date( 'm', strtotime( $start_date ) );
 						$y = date( 'Y', strtotime( $start_date ) );
@@ -1263,7 +1282,13 @@ class EDD_API {
 						$key = $y . $m . $d;
 
 						if ( ! isset( $sales['sales'][ $key ] ) ) {
-							$sales['sales'][ $key ] = 0;
+							$sales['sales'][ $key ] = $stats->get_order_count(
+								array(
+									'start'        => $dates['start']->format( 'Y-m-d H:i:s' ),
+									'end'          => $dates['end']->format( 'Y-m-d H:i:s' ),
+									'revenue_type' => 'net',
+								)
+							);
 						}
 
 						$start_date = date( 'Y-m-d', strtotime( '+1 day', strtotime( $start_date ) ) );
@@ -1271,46 +1296,47 @@ class EDD_API {
 
 					ksort( $sales['sales'] );
 
-					$sales['totals'] = array_sum( $sales['sales'] );
+					$sales['totals'] = $total_sales;
+
 				} else {
-					$start_date = $dates['year'] . '-' . $dates['m_start'] . '-' . $dates['day'];
-					$end_date   = $dates['year'] . '-' . $dates['m_end'] . '-' . $dates['day_end'];
-
-					$stats = EDD()->payment_stats->get_sales_by_range( $args['date'], false, $start_date, $end_date );
-					if ( $stats instanceof WP_Error ) {
-
-						$error_message = __( 'There was an error retrieving earnings.', 'easy-digital-downloads' );
-
-						foreach ( $stats->errors as $error_key => $error_array ) {
-							if ( ! empty( $error_array[0] ) ) {
-								$error_message = $error_array[0];
-							}
-						}
-
-						$error['error'] = sprintf( '%s %s', $error_message, $args['date'] );
-					} else {
-						if ( empty( $stats ) ) {
-							$sales['sales'][ $args['date'] ] = 0;
-						} else {
-							$total_sales = 0;
-							foreach ( $stats as $date ) {
-								$total_sales += (int) $date['count'];
-							}
-							$sales['sales'][ $args['date'] ] = $total_sales;
-						}
-					}
+					$stats = new EDD\Stats(
+						array(
+							'range'        => $args['date'],
+							'revenue_type' => 'net',
+						)
+					);
+					$sales['sales'][ $args['date'] ] = $stats->get_order_count();
 				}
 			} elseif ( $args['product'] == 'all' ) {
 				$products = get_posts( array( 'post_type' => 'download', 'nopaging' => true ) );
 				$i        = 0;
+
+				$stats = new EDD\Stats();
 				foreach ( $products as $product_info ) {
-					$sales['sales'][ $i ] = array( $product_info->post_name => edd_get_download_sales_stats( $product_info->ID ) );
+					$product_order_count = $stats->get_order_item_count(
+						array(
+							'product_id' => $product_info->ID,
+						)
+					);
+
+					$sales['sales'][ $i ] = array(
+						$product_info->post_name => $product_order_count,
+					);
 					$i ++;
 				}
 			} else {
-				if ( get_post_type( $args['product'] ) == 'download' ) {
-					$product_info      = get_post( $args['product'] );
-					$sales['sales'][0] = array( $product_info->post_name => edd_get_download_sales_stats( $args['product'] ) );
+				if ( get_post_type( $args['product'] ) === 'download' ) {
+					$stats            = new EDD\Stats();
+					$product_info     = get_post( $args['product'] );
+					$order_item_count = $stats->get_order_item_count(
+						array(
+							'product_id' => $args['product'],
+						)
+					);
+
+					$sales['sales'][0] = array(
+						$product_info->post_name => $order_item_count,
+					);
 				} else {
 					$error['error'] = sprintf( __( 'Product %s not found!', 'easy-digital-downloads' ), $args['product'] );
 				}
@@ -1321,7 +1347,7 @@ class EDD_API {
 			}
 
 			return apply_filters( 'edd_api_stats_sales', $sales, $this );
-		} elseif ( $args['type'] == 'earnings' ) {
+		} elseif ( $args['type'] === 'earnings' ) {
 			if ( $args['product'] == null ) {
 				if ( $args['date'] == null ) {
 					$earnings = $this->get_default_earnings_stats( $args );
@@ -1338,96 +1364,102 @@ class EDD_API {
 						$error['error'] = __( 'Invalid or no date range specified!', 'easy-digital-downloads' );
 					}
 
-					$total = (float) 0.00;
+					$start_date = $dates['year'] . '-' . $dates['m_start'] . '-' . $dates['day_start'];
+					$end_date   = $dates['year_end'] . '-' . $dates['m_end'] . '-' . $dates['day_end'];
 
-					// Loop through the years
-					if ( ! isset( $earnings['earnings'] ) ) {
-						$earnings['earnings'] = array();
-					}
+					// Force the data for the reports API.
+					$_GET['filter_from'] = $start_date;
+					$_GET['filter_to']   = $end_date;
+					$_GET['range']       = 'other';
 
-					if ( cal_days_in_month( CAL_GREGORIAN, $dates['m_start'], $dates['year'] ) < $dates['day_start'] ) {
-						$next_day   = mktime( 0, 0, 0, $dates['m_start'] + 1, 1, $dates['year'] );
-						$day        = date( 'd', $next_day );
-						$month      = date( 'm', $next_day );
-						$year       = date( 'Y', $next_day );
-						$date_start = $year . '-' . $month . '-' . $day;
-					} else {
-						$date_start = $dates['year'] . '-' . $dates['m_start'] . '-' . $dates['day_start'];
-					}
+					$stats   = new EDD\Stats();
+					$dates   = EDD\Reports\parse_dates_for_range();
 
-					if ( cal_days_in_month( CAL_GREGORIAN, $dates['m_end'], $dates['year'] ) < $dates['day_end'] ) {
-						$date_end = $dates['year_end'] . '-' . $dates['m_end'] . '-' . cal_days_in_month( CAL_GREGORIAN, $dates['m_end'], $dates['year'] );
-					} else {
-						$date_end = $dates['year_end'] . '-' . $dates['m_end'] . '-' . $dates['day_end'];
-					}
+					$total_earnings = $stats->get_order_earnings(
+						array(
+							'start'         => $dates['start']->format( 'Y-m-d H:i:s' ),
+							'end'           => $dates['end']->format( 'Y-m-d H:i:s' ),
+							'revenue_type'  => 'net',
+							'exclude_taxes' => ! $args['include_tax'],
+						)
+					);
 
-					$earnings = EDD()->payment_stats->get_earnings_by_range( 'other', true, $date_start, $date_end, $args['include_tax'] );
+					$start_date  = date( 'Y-m-d', strtotime( $start_date ) );
+					$end_date    = date( 'Y-m-d', strtotime( $end_date ) );
 
-					$total = 0;
+					$earnings['earnings'] = array();
+					while ( strtotime( $start_date ) <= strtotime( $end_date ) ) {
 
-					foreach ( $earnings as $earning ) {
-						$temp_data['earnings'][ $earning['y'] . $earning['m'] . $earning['d'] ] = (float) $earning['total'];
-						$total += (float) $earning['total'];
-					}
+						// Force the data for the reports API.
+						$_GET['filter_from'] = $start_date;
+						$_GET['filter_to']   = $start_date;
+						$_GET['range']       = 'other';
 
-					$date_start = date( 'Y-m-d', strtotime( $date_start ) );
-					$date_end   = date( 'Y-m-d', strtotime( $date_end ) );
+						$dates = EDD\Reports\parse_dates_for_range();
 
-					while ( strtotime( $date_start ) <= strtotime( $date_end ) ) {
-						$d = date( 'd', strtotime( $date_start ) );
-						$m = date( 'm', strtotime( $date_start ) );
-						$y = date( 'Y', strtotime( $date_start ) );
+						$d = date( 'd', strtotime( $start_date ) );
+						$m = date( 'm', strtotime( $start_date ) );
+						$y = date( 'Y', strtotime( $start_date ) );
 
 						$key = $y . $m . $d;
 
-						if ( ! isset( $temp_data['earnings'][ $key ] ) ) {
-							$temp_data['earnings'][ $key ] = 0;
+						if ( ! isset( $sales['earnings'][ $key ] ) ) {
+							$earnings['earnings'][ $key ] = $stats->get_order_earnings(
+								array(
+									'start'         => $dates['start']->format( 'Y-m-d H:i:s' ),
+									'end'           => $dates['end']->format( 'Y-m-d H:i:s' ),
+									'revenue_type'  => 'net',
+									'exclude_taxes' => ! $args['include_tax'],
+								)
+							);
 						}
 
-						$date_start = date( 'Y-m-d', strtotime( '+1 day', strtotime( $date_start ) ) );
+						$start_date = date( 'Y-m-d', strtotime( '+1 day', strtotime( $start_date ) ) );
 					}
 
-					ksort( $temp_data['earnings'] );
+					ksort( $earnings['earnings'] );
 
-					$earnings = $temp_data;
-
-					$earnings['totals'] = $total;
+					$earnings['totals'] = $total_earnings;
 				} else {
-					$date_start = $dates['year'] . '-' . $dates['m_start'] . '-' . $dates['day'];
-					$date_end   = $dates['year'] . '-' . $dates['m_end'] . '-' . $dates['day_end'];
-
-					$results = EDD()->payment_stats->get_earnings_by_range( $args['date'], false, $date_start, $date_end, $args['include_tax'] );
-					if ( $results instanceof WP_Error ) {
-						$error_message = __( 'There was an error retrieving earnings.', 'easy-digital-downloads' );
-
-						foreach ( $results->errors as $error_key => $error_array ) {
-							if ( ! empty( $error_array[0] ) ) {
-								$error_message = $error_array[0];
-							}
-						}
-
-						$error['error'] = sprintf( '%s %s', $error_message, $args['date'] );
-					} else {
-						$total_earnings = 0;
-						foreach ( $results as $result ) {
-							$total_earnings += $result['total'];
-						}
-
-						$earnings['earnings'][ $args['date'] ] = edd_format_amount( $total_earnings );
-					}
+					$stats = new EDD\Stats(
+						array(
+							'range'        => $args['date'],
+							'revenue_type' => 'net',
+							'exclude_tax'  => ! $args['include_tax'],
+						)
+					);
+					$earnings['earnings'][ $args['date'] ] = $stats->get_order_earnings();
 				}
 			} elseif ( $args['product'] == 'all' ) {
 				$products = get_posts( array( 'post_type' => 'download', 'nopaging' => true ) );
+				$i        = 0;
 
-				$i = 0;
+				$stats = new EDD\Stats();
 				foreach ( $products as $product_info ) {
-					$earnings['earnings'][ $i ] = array( $product_info->post_name => edd_get_download_earnings_stats( $product_info->ID ) );
+					$product_earnings = $stats->get_order_item_earnings(
+						array(
+							'product_id'   => $product_info->ID,
+						)
+					);
+
+					$earnings['earnings'][ $i ] = array(
+						$product_info->post_name => $product_earnings,
+					);
 					$i ++;
 				}
 			} else {
-				if ( get_post_type( $args['product'] ) == 'download' ) {
-					$product_info            = get_post( $args['product'] );
-					$earnings['earnings'][0] = array( $product_info->post_name => edd_get_download_earnings_stats( $args['product'] ) );
+				if ( get_post_type( $args['product'] ) === 'download' ) {
+					$stats               = new EDD\Stats();
+					$product_info        = get_post( $args['product'] );
+					$order_item_earnings = $stats->get_order_item_earnings(
+						array(
+							'product_id' => $args['product'],
+						)
+					);
+
+					$earnings['earnings'][0] = array(
+						$product_info->post_name => $order_item_earnings,
+					);
 				} else {
 					$error['error'] = sprintf( __( 'Product %s not found!', 'easy-digital-downloads' ), $args['product'] );
 				}
@@ -1439,18 +1471,9 @@ class EDD_API {
 
 			return apply_filters( 'edd_api_stats_earnings', $earnings, $this );
 		} elseif ( $args['type'] == 'customers' ) {
-			if ( version_compare( $edd_version, '2.3', '<' ) || ! edd_has_upgrade_completed( 'upgrade_customer_payments_association' ) ) {
-				global $wpdb;
-				$stats                                 = array();
-				$count                                 = $wpdb->get_col( "SELECT COUNT(DISTINCT meta_value) FROM $wpdb->postmeta WHERE meta_key = '_edd_payment_user_email'" );
-				$stats['customers']['total_customers'] = $count[0];
+			$stats['customers']['total_customers'] = edd_count_customers();
 
-				return apply_filters( 'edd_api_stats_customers', $stats, $this );
-			} else {
-				$stats['customers']['total_customers'] = edd_count_customers();
-
-				return apply_filters( 'edd_api_stats_customers', $stats, $this );
-			}
+			return apply_filters( 'edd_api_stats_customers', $stats, $this );
 		} elseif ( empty( $args['type'] ) ) {
 			$stats = array_merge( $stats, $this->get_default_sales_stats() );
 			$stats = array_merge( $stats, $this->get_default_earnings_stats( $args ) );
@@ -2241,12 +2264,31 @@ class EDD_API {
 	 */
 	private function get_default_sales_stats() {
 
-		// Default sales return
-		$sales                           = array();
-		$sales['sales']['today']         = $this->stats->get_sales( 0, 'today' );
-		$sales['sales']['current_month'] = $this->stats->get_sales( 0, 'this_month' );
-		$sales['sales']['last_month']    = $this->stats->get_sales( 0, 'last_month' );
-		$sales['sales']['totals']        = edd_get_total_sales();
+		$stats = new EDD\Stats(
+			array(
+				'range'        => 'today',
+				'revenue_type' => 'net',
+			)
+		);
+		$sales['sales']['today'] = $stats->get_order_count();
+
+		$stats = new EDD\Stats(
+			array(
+				'range'        => 'this_month',
+				'revenue_type' => 'net',
+			)
+		);
+		$sales['sales']['current_month'] = $stats->get_order_count();
+
+		$stats = new EDD\Stats(
+			array(
+				'range'        => 'last_month',
+				'revenue_type' => 'net',
+			)
+		);
+		$sales['sales']['last_month'] = $stats->get_order_count();
+
+		$sales['sales']['totals'] = edd_get_total_sales();
 
 		return $sales;
 	}
@@ -2260,12 +2302,34 @@ class EDD_API {
 	 */
 	private function get_default_earnings_stats( $args ) {
 
-		// Default earnings return
-		$earnings                              = array();
-		$earnings['earnings']['today']         = $this->stats->get_earnings( 0, 'today', null, $args['include_tax'] );
-		$earnings['earnings']['current_month'] = $this->stats->get_earnings( 0, 'this_month', null, $args['include_tax'] );
-		$earnings['earnings']['last_month']    = $this->stats->get_earnings( 0, 'last_month', null, $args['include_tax'] );
-		$earnings['earnings']['totals']        = edd_get_total_earnings( $args['include_tax'] );
+		$stats  = new EDD\Stats(
+			array(
+				'range'         => 'today',
+				'exclude_taxes' => ! $args['include_tax'],
+				'revenue_type'  => 'net',
+			)
+		);
+		$earnings['earnings']['today'] = $stats->get_order_earnings();
+
+		$stats  = new EDD\Stats(
+			array(
+				'range'         => 'this_month',
+				'exclude_taxes' => ! $args['include_tax'],
+				'revenue_type'  => 'net',
+			)
+		);
+		$earnings['earnings']['current_month'] = $stats->get_order_earnings();
+
+		$stats  = new EDD\Stats(
+			array(
+				'range'         => 'last_month',
+				'exclude_taxes' => ! $args['include_tax'],
+				'revenue_type'  => 'net',
+			)
+		);
+		$earnings['earnings']['last_month'] = $stats->get_order_earnings();
+
+		$earnings['earnings']['totals'] = edd_get_total_earnings( $args['include_tax'] );
 
 		return $earnings;
 	}

--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -1253,19 +1253,22 @@ class EDD_API {
 					$_GET['filter_to']   = $end_date;
 					$_GET['range']       = 'other';
 
-					$stats   = new EDD\Stats();
-					$dates   = EDD\Reports\parse_dates_for_range();
-
-					$total_sales = $stats->get_order_count(
+					$stats = new EDD\Stats(
 						array(
-							'start'        => $dates['start']->format( 'Y-m-d H:i:s' ),
-							'end'          => $dates['end']->format( 'Y-m-d H:i:s' ),
 							'revenue_type' => 'net',
 						)
 					);
+					$dates = EDD\Reports\parse_dates_for_range();
 
-					$start_date  = $dates['start']->format( 'Y-m-d' );
-					$end_date    = $dates['end']->format( 'Y-m-d' );
+					$total_sales = $stats->get_order_count(
+						array(
+							'start' => $dates['start']->format( 'Y-m-d H:i:s' ),
+							'end'   => $dates['end']->format( 'Y-m-d H:i:s' ),
+						)
+					);
+
+					$start_date = $dates['start']->format( 'Y-m-d' );
+					$end_date   = $dates['end']->format( 'Y-m-d' );
 
 					while ( strtotime( $start_date ) <= strtotime( $end_date ) ) {
 
@@ -1285,9 +1288,8 @@ class EDD_API {
 						if ( ! isset( $sales['sales'][ $key ] ) ) {
 							$sales['sales'][ $key ] = $stats->get_order_count(
 								array(
-									'start'        => $dates['start']->format( 'Y-m-d H:i:s' ),
-									'end'          => $dates['end']->format( 'Y-m-d H:i:s' ),
-									'revenue_type' => 'net',
+									'start' => $dates['start']->format( 'Y-m-d H:i:s' ),
+									'end'   => $dates['end']->format( 'Y-m-d H:i:s' ),
 								)
 							);
 						}
@@ -1306,6 +1308,7 @@ class EDD_API {
 							'revenue_type' => 'net',
 						)
 					);
+
 					$sales['sales'][ $args['date'] ] = $stats->get_order_count();
 				}
 			} elseif ( $args['product'] == 'all' ) {
@@ -1373,20 +1376,23 @@ class EDD_API {
 					$_GET['filter_to']   = $end_date;
 					$_GET['range']       = 'other';
 
-					$stats   = new EDD\Stats();
-					$dates   = EDD\Reports\parse_dates_for_range();
-
-					$total_earnings = $stats->get_order_earnings(
+					$stats = new EDD\Stats(
 						array(
-							'start'         => $dates['start']->format( 'Y-m-d H:i:s' ),
-							'end'           => $dates['end']->format( 'Y-m-d H:i:s' ),
 							'revenue_type'  => 'net',
 							'exclude_taxes' => ! $args['include_tax'],
 						)
 					);
+					$dates = EDD\Reports\parse_dates_for_range();
 
-					$start_date  = $dates['start']->format( 'Y-m-d' );
-					$end_date    = $dates['end']->format( 'Y-m-d' );
+					$total_earnings = $stats->get_order_earnings(
+						array(
+							'start' => $dates['start']->format( 'Y-m-d H:i:s' ),
+							'end'   => $dates['end']->format( 'Y-m-d H:i:s' ),
+						)
+					);
+
+					$start_date = $dates['start']->format( 'Y-m-d' );
+					$end_date   = $dates['end']->format( 'Y-m-d' );
 
 					$earnings['earnings'] = array();
 					while ( strtotime( $start_date ) <= strtotime( $end_date ) ) {
@@ -1407,10 +1413,8 @@ class EDD_API {
 						if ( ! isset( $sales['earnings'][ $key ] ) ) {
 							$earnings['earnings'][ $key ] = $stats->get_order_earnings(
 								array(
-									'start'         => $dates['start']->format( 'Y-m-d H:i:s' ),
-									'end'           => $dates['end']->format( 'Y-m-d H:i:s' ),
-									'revenue_type'  => 'net',
-									'exclude_taxes' => ! $args['include_tax'],
+									'start' => $dates['start']->format( 'Y-m-d H:i:s' ),
+									'end'   => $dates['end']->format( 'Y-m-d H:i:s' ),
 								)
 							);
 						}

--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -1382,8 +1382,8 @@ class EDD_API {
 
 					$total_earnings = $stats->get_order_earnings(
 						array(
-							'start' => $dates['start']->format( 'Y-m-d H:i:s' ),
-							'end'   => $dates['end']->format( 'Y-m-d H:i:s' ),
+							'start'  => $dates['start']->format( 'Y-m-d H:i:s' ),
+							'end'    => $dates['end']->format( 'Y-m-d H:i:s' ),
 						)
 					);
 

--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -1277,24 +1277,19 @@ class EDD_API {
 						$_GET['filter_to']   = $start_date;
 						$_GET['range']       = 'other';
 
+						$key   = str_replace( '-', '', $start_date );
 						$dates = EDD\Reports\parse_dates_for_range();
-
-						$d = date( 'd', strtotime( $start_date ) );
-						$m = date( 'm', strtotime( $start_date ) );
-						$y = date( 'Y', strtotime( $start_date ) );
-
-						$key = $y . $m . $d;
 
 						if ( ! isset( $sales['sales'][ $key ] ) ) {
 							$sales['sales'][ $key ] = $stats->get_order_count(
 								array(
-									'start' => $dates['start']->format( 'Y-m-d H:i:s' ),
-									'end'   => $dates['end']->format( 'Y-m-d H:i:s' ),
+									'start' => $dates['start']->startOfDay()->format( 'Y-m-d H:i:s' ),
+									'end'   => $dates['end']->endOfDay()->format( 'Y-m-d H:i:s' ),
 								)
 							);
 						}
 
-						$start_date = date( 'Y-m-d', strtotime( '+1 day', strtotime( $start_date ) ) );
+						$start_date = $dates['start']->addDays( 1 )->format( 'Y-m-d' );
 					}
 
 					ksort( $sales['sales'] );
@@ -1402,13 +1397,8 @@ class EDD_API {
 						$_GET['filter_to']   = $start_date;
 						$_GET['range']       = 'other';
 
+						$key   = str_replace( '-', '', $start_date );
 						$dates = EDD\Reports\parse_dates_for_range();
-
-						$d = date( 'd', strtotime( $start_date ) );
-						$m = date( 'm', strtotime( $start_date ) );
-						$y = date( 'Y', strtotime( $start_date ) );
-
-						$key = $y . $m . $d;
 
 						if ( ! isset( $sales['earnings'][ $key ] ) ) {
 							$earnings['earnings'][ $key ] = $stats->get_order_earnings(
@@ -1419,7 +1409,7 @@ class EDD_API {
 							);
 						}
 
-						$start_date = date( 'Y-m-d', strtotime( '+1 day', strtotime( $start_date ) ) );
+						$start_date = $dates['start']->addDays( 1 )->format( 'Y-m-d' );
 					}
 
 					ksort( $earnings['earnings'] );

--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -1263,8 +1263,9 @@ class EDD_API {
 							'revenue_type' => 'net',
 						)
 					);
-					$start_date  = date( 'Y-m-d', strtotime( $start_date ) );
-					$end_date    = date( 'Y-m-d', strtotime( $end_date ) );
+
+					$start_date  = $dates['start']->format( 'Y-m-d' );
+					$end_date    = $dates['end']->format( 'Y-m-d' );
 
 					while ( strtotime( $start_date ) <= strtotime( $end_date ) ) {
 
@@ -1384,8 +1385,8 @@ class EDD_API {
 						)
 					);
 
-					$start_date  = date( 'Y-m-d', strtotime( $start_date ) );
-					$end_date    = date( 'Y-m-d', strtotime( $end_date ) );
+					$start_date  = $dates['start']->format( 'Y-m-d' );
+					$end_date    = $dates['end']->format( 'Y-m-d' );
 
 					$earnings['earnings'] = array();
 					while ( strtotime( $start_date ) <= strtotime( $end_date ) ) {

--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -1375,6 +1375,7 @@ class EDD_API {
 						array(
 							'revenue_type'  => 'net',
 							'exclude_taxes' => ! $args['include_tax'],
+							'output'        => 'typed',
 						)
 					);
 					$dates = EDD\Reports\parse_dates_for_range();
@@ -1421,6 +1422,7 @@ class EDD_API {
 							'range'        => $args['date'],
 							'revenue_type' => 'net',
 							'exclude_tax'  => ! $args['include_tax'],
+							'output'       => 'typed',
 						)
 					);
 					$earnings['earnings'][ $args['date'] ] = $stats->get_order_earnings();
@@ -1433,7 +1435,8 @@ class EDD_API {
 				foreach ( $products as $product_info ) {
 					$product_earnings = $stats->get_order_item_earnings(
 						array(
-							'product_id'   => $product_info->ID,
+							'product_id' => $product_info->ID,
+							'output'     => 'typed',
 						)
 					);
 
@@ -1449,6 +1452,7 @@ class EDD_API {
 					$order_item_earnings = $stats->get_order_item_earnings(
 						array(
 							'product_id' => $args['product'],
+							'output'     => 'typed',
 						)
 					);
 
@@ -2302,6 +2306,7 @@ class EDD_API {
 				'range'         => 'today',
 				'exclude_taxes' => ! $args['include_tax'],
 				'revenue_type'  => 'net',
+				'output'        => 'typed',
 			)
 		);
 		$earnings['earnings']['today'] = $stats->get_order_earnings();
@@ -2311,6 +2316,7 @@ class EDD_API {
 				'range'         => 'this_month',
 				'exclude_taxes' => ! $args['include_tax'],
 				'revenue_type'  => 'net',
+				'output'        => 'typed',
 			)
 		);
 		$earnings['earnings']['current_month'] = $stats->get_order_earnings();
@@ -2320,6 +2326,7 @@ class EDD_API {
 				'range'         => 'last_month',
 				'exclude_taxes' => ! $args['include_tax'],
 				'revenue_type'  => 'net',
+				'output'        => 'typed',
 			)
 		);
 		$earnings['earnings']['last_month'] = $stats->get_order_earnings();

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -2862,7 +2862,7 @@ class Stats {
 		if ( is_object( $data ) ) {
 			foreach ( array_keys( get_object_vars( $data ) ) as $field ) {
 				if ( is_numeric( $data->{$field} ) ) {
-					$data->{$field} = edd_format_amount( $data->{$field} );
+					$data->{$field} = edd_format_amount( $data->{$field}, true, $currency, $output );
 
 					if ( 'formatted' === $output ) {
 						$data->{$field} = edd_currency_filter( $data->{$field}, $currency );
@@ -2872,7 +2872,7 @@ class Stats {
 		} elseif ( is_array( $data ) ) {
 			foreach ( array_keys( $data ) as $field ) {
 				if ( is_numeric( $data[ $field ] ) ) {
-					$data[ $field ] = edd_format_amount( $data[ $field ] );
+					$data[ $field ] = edd_format_amount( $data[ $field ], true, $currency, $output );
 
 					if ( 'formatted' === $output ) {
 						$data[ $field ] = edd_currency_filter( $data[ $field ], $currency );
@@ -2881,7 +2881,7 @@ class Stats {
 			}
 		} else {
 			if ( is_numeric( $data ) ) {
-				$data = edd_format_amount( $data );
+				$data = edd_format_amount( $data, true, $currency, $output );
 
 				if ( 'formatted' === $output ) {
 					$data = edd_currency_filter( $data, $currency );

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -2849,7 +2849,7 @@ class Stats {
 			? $this->query_vars['output']
 			: 'raw';
 
-			// Return data as is if the format is raw.
+		// Return data as is if the format is raw.
 		if ( 'raw' === $output ) {
 			return $data;
 		}

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -2842,14 +2842,14 @@ class Stats {
 			return $data;
 		}
 
-		$allowed_output_formats = array( 'raw', 'formatted' );
+		$allowed_output_formats = array( 'raw', 'typed', 'formatted' );
 
 		// Output format. Default raw.
 		$output = isset( $this->query_vars['output'] ) && in_array( $this->query_vars['output'], $allowed_output_formats, true )
 			? $this->query_vars['output']
 			: 'raw';
 
-		// Return data as is if the format is raw.
+			// Return data as is if the format is raw.
 		if ( 'raw' === $output ) {
 			return $data;
 		}
@@ -2862,18 +2862,30 @@ class Stats {
 		if ( is_object( $data ) ) {
 			foreach ( array_keys( get_object_vars( $data ) ) as $field ) {
 				if ( is_numeric( $data->{$field} ) ) {
-					$data->{$field} = edd_currency_filter( edd_format_amount( $data->{$field} ), $currency );
+					$data->{$field} = edd_format_amount( $data->{$field} );
+
+					if ( 'formatted' === $output ) {
+						$data->{$field} = edd_currency_filter( $data->{$field}, $currency );
+					}
 				}
 			}
 		} elseif ( is_array( $data ) ) {
 			foreach ( array_keys( $data ) as $field ) {
 				if ( is_numeric( $data[ $field ] ) ) {
-					$data[ $field ] = edd_currency_filter( edd_format_amount( $data[ $field ] ), $currency );
+					$data[ $field ] = edd_format_amount( $data[ $field ] );
+
+					if ( 'formatted' === $output ) {
+						$data[ $field ] = edd_currency_filter( $data[ $field ], $currency );
+					}
 				}
 			}
 		} else {
 			if ( is_numeric( $data ) ) {
-				$data = edd_currency_filter( edd_format_amount( $data ), $currency );
+				$data = edd_format_amount( $data );
+
+				if ( 'formatted' === $output ) {
+					$data = edd_currency_filter( $data, $currency );
+				}
 			}
 		}
 

--- a/includes/currency/class-money-formatter.php
+++ b/includes/currency/class-money-formatter.php
@@ -41,8 +41,10 @@ class Money_Formatter {
 	 * @param Currency $currency
 	 */
 	public function __construct( $amount, Currency $currency ) {
-		$this->amount   = $this->original_amount = $amount;
-		$this->currency = $currency;
+		$this->original_amount = $amount;
+		$this->amount          = $amount;
+		$this->typed_amount    = $amount;
+		$this->currency        = $currency;
 	}
 
 	/**
@@ -155,8 +157,15 @@ class Money_Formatter {
 
 		$decimals = $this->get_decimals( $decimals, $amount );
 
-		// Format amount using decimals and separators (also rounds up or down). We intentionally are not filtering here as it casues a data type issue.
-		$formatted = number_format( (float) $amount, $decimals, $this->currency->decimal_separator, $this->currency->thousands_separator );
+		/**
+		 * Since we want to return a float value here, intentionally only supply a decimal separator.
+		 *
+		 * The separators here are hard coded intentionally as we're looking to get truncated, raw format of float
+		 * which requires '.' for decimal separators and no thousands separator.
+		 *
+		 * This is also intentionally not filtered for the time being.
+		 */
+		$formatted = floatval( number_format( (float) $amount, $decimals, '.', '' ) );
 
 		// Set the amount to $this->amount.
 		$this->typed_amount = $formatted;

--- a/includes/currency/class-money-formatter.php
+++ b/includes/currency/class-money-formatter.php
@@ -69,19 +69,17 @@ class Money_Formatter {
 	}
 
 	/**
-	 * Formats the amount for display.
-	 * Does not apply the currency code.
+	 * Returns the number of decimals ot use for the formatted amount.
 	 *
-	 * @since 3.0
-	 * @return Money_Formatter
+	 * Based on the currency code used when instantiating the class, determines how many
+	 * decimal points the value should have once formatted.
+	 *
+	 * @param bool  $decimals If we should include decimals or not in the formatted amount.
+	 * @param float $amount   The amount to format.
+	 *
+	 * @return int  The number of decimals places to use when formatting the amount.
 	 */
-	public function format_for_display( $decimals = true ) {
-		$amount = $this->unformat();
-
-		if ( empty( $amount ) ) {
-			$amount = 0;
-		}
-
+	private function get_decimals( $decimals, $amount ) {
 		/**
 		 * Filter number of decimals to use for formatted amount
 		 *
@@ -91,9 +89,29 @@ class Money_Formatter {
 		 * @param int|string $amount        Amount being formatted.
 		 * @param string     $currency_code Currency code being formatted.
 		 */
-		$decimals = apply_filters( 'edd_format_amount_decimals', $decimals ? $this->currency->number_decimals : 0, $amount, $this->currency->code );
+		return apply_filters( 'edd_format_amount_decimals', $decimals ? $this->currency->number_decimals : 0, $amount, $this->currency->code );
+	}
 
-		// Format amount using decimals and separators (also rounds up or down)
+	/**
+	 * Formats the amount for display.
+	 * Does not apply the currency code.
+	 *
+	 * @since 3.0
+	 *
+	 * @param bool $decimals If we should include decimal places or not when formatting.
+	 *
+	 * @return Money_Formatter
+	 */
+	public function format_for_display( $decimals = true ) {
+		$amount = $this->unformat();
+
+		if ( empty( $amount ) ) {
+			$amount = 0;
+		}
+
+		$decimals = $this->get_decimals( $decimals, $amount );
+
+		// Format amount using decimals and separators (also rounds up or down).
 		$formatted = number_format( (float) $amount, $decimals, $this->currency->decimal_separator, $this->currency->thousands_separator );
 
 		/**
@@ -118,6 +136,9 @@ class Money_Formatter {
 	 * Does not apply the currency code and returns a foat instead of a string.
 	 *
 	 * @since 3.0
+	 *
+	 * @param bool $decimals If we should include decimal places or not when formatting.
+	 *
 	 * @return Money_Formatter
 	 */
 	public function format_for_typed( $decimals = true ) {
@@ -127,19 +148,13 @@ class Money_Formatter {
 			$amount = 0;
 		}
 
-		/**
-		 * Filter number of decimals to use for formatted amount
-		 *
-		 * @since unknown
-		 *
-		 * @param int        $number        Default 2. Number of decimals.
-		 * @param int|string $amount        Amount being formatted.
-		 * @param string     $currency_code Currency code being formatted.
-		 */
-		$decimals = apply_filters( 'edd_format_amount_decimals', $decimals ? $this->currency->number_decimals : 0, $amount, $this->currency->code );
+		$decimals = $this->get_decimals( $decimals, $amount );
 
-		// Format amount using decimals and separators (also rounds up or down).
+		// Format amount using decimals and separators (also rounds up or down). We intentionally are not filtering here as it casues a data type issue.
 		$formatted = number_format( (float) $amount, $decimals, $this->currency->decimal_separator, $this->currency->thousands_separator );
+
+		// Set the amount to $this->amount.
+		$this->amount = $formatted;
 
 		return $this;
 	}

--- a/includes/currency/class-money-formatter.php
+++ b/includes/currency/class-money-formatter.php
@@ -20,6 +20,11 @@ class Money_Formatter {
 	public $amount;
 
 	/**
+	 * @var float Typed amount.
+	 */
+	public $typed_amount;
+
+	/**
 	 * @var int|float Original, unmodified amount passed in via constructor.
 	 */
 	private $original_amount;
@@ -49,7 +54,7 @@ class Money_Formatter {
 	 * @return float|int
 	 */
 	private function unformat() {
-		$amount = $this->amount;
+		$amount = $this->original_amount;
 
 		$sep_found = strpos( $amount, $this->currency->decimal_separator );
 		if ( ',' === $this->currency->decimal_separator && false !== $sep_found ) {
@@ -154,7 +159,7 @@ class Money_Formatter {
 		$formatted = number_format( (float) $amount, $decimals, $this->currency->decimal_separator, $this->currency->thousands_separator );
 
 		// Set the amount to $this->amount.
-		$this->amount = $formatted;
+		$this->typed_amount = $formatted;
 
 		return $this;
 	}

--- a/includes/currency/class-money-formatter.php
+++ b/includes/currency/class-money-formatter.php
@@ -114,6 +114,37 @@ class Money_Formatter {
 	}
 
 	/**
+	 * Formats the amount for API returns.
+	 * Does not apply the currency code and returns a foat instead of a string.
+	 *
+	 * @since 3.0
+	 * @return Money_Formatter
+	 */
+	public function format_for_api( $decimals = true ) {
+		$amount = $this->unformat();
+
+		if ( empty( $amount ) ) {
+			$amount = 0;
+		}
+
+		/**
+		 * Filter number of decimals to use for formatted amount
+		 *
+		 * @since unknown
+		 *
+		 * @param int        $number        Default 2. Number of decimals.
+		 * @param int|string $amount        Amount being formatted.
+		 * @param string     $currency_code Currency code being formatted.
+		 */
+		$decimals = apply_filters( 'edd_format_amount_decimals', $decimals ? $this->currency->number_decimals : 0, $amount, $this->currency->code );
+
+		// Format amount using decimals and separators (also rounds up or down)
+		$formatted = number_format( (float) $amount, $decimals, $this->currency->decimal_separator, $this->currency->thousands_separator );
+
+		return $this;
+	}
+
+	/**
 	 * Applies the currency prefix/suffix to the amount.
 	 *
 	 * @since 3.0

--- a/includes/currency/class-money-formatter.php
+++ b/includes/currency/class-money-formatter.php
@@ -114,13 +114,13 @@ class Money_Formatter {
 	}
 
 	/**
-	 * Formats the amount for API returns.
+	 * Formats the amount for typed data returns.
 	 * Does not apply the currency code and returns a foat instead of a string.
 	 *
 	 * @since 3.0
 	 * @return Money_Formatter
 	 */
-	public function format_for_api( $decimals = true ) {
+	public function format_for_typed( $decimals = true ) {
 		$amount = $this->unformat();
 
 		if ( empty( $amount ) ) {
@@ -138,7 +138,7 @@ class Money_Formatter {
 		 */
 		$decimals = apply_filters( 'edd_format_amount_decimals', $decimals ? $this->currency->number_decimals : 0, $amount, $this->currency->code );
 
-		// Format amount using decimals and separators (also rounds up or down)
+		// Format amount using decimals and separators (also rounds up or down).
 		$formatted = number_format( (float) $amount, $decimals, $this->currency->decimal_separator, $this->currency->thousands_separator );
 
 		return $this;

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -128,7 +128,7 @@ function edd_format_amount( $amount = 0, $decimals = true, $currency = '', $cont
 
 	switch ( $context ) {
 		case 'typed':
-			$return_value = $formatter->format_for_api( $decimals )->amount;
+			$return_value = $formatter->format_for_typed( $decimals )->amount;
 			break;
 		case 'display':
 		default:

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -128,7 +128,7 @@ function edd_format_amount( $amount = 0, $decimals = true, $currency = '', $cont
 
 	switch ( $context ) {
 		case 'typed':
-			$return_value = $formatter->format_for_typed( $decimals )->amount;
+			$return_value = $formatter->format_for_typed( $decimals )->typed_amount;
 			break;
 		case 'display':
 		default:

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -115,17 +115,28 @@ function edd_sanitize_amount( $amount = 0 ) {
  * @param string $decimals Default true. Whether or not to use decimals. Useful when set to false for non-currency numbers.
  * @param string $currency Currency code to format the amount for. This determines how many decimals are used.
  *                         If omitted, site-wide currency is used.
+ * @param string $context  Defines the context in which we are formatting the data (formatted), for display or for data useage like API (typed).
  *
  * @return string $amount Newly formatted amount or Price Not Available
  */
-function edd_format_amount( $amount = 0, $decimals = true, $currency = '' ) {
+function edd_format_amount( $amount = 0, $decimals = true, $currency = '', $context = 'display' ) {
 	if ( empty( $currency ) ) {
 		$currency = edd_get_currency();
 	}
 
 	$formatter = new \EDD\Currency\Money_Formatter( $amount, new \EDD\Currency\Currency( $currency ) );
 
-	return $formatter->format_for_display( $decimals )->amount;
+	switch ( $context ) {
+		case 'typed':
+			$return_value = $formatter->format_for_api( $decimals )->amount;
+			break;
+		case 'display':
+		default:
+			$return_value = $formatter->format_for_display( $decimals )->amount;
+			break;
+	}
+
+	return $return_value;
 }
 
 /**

--- a/includes/payments/actions.php
+++ b/includes/payments/actions.php
@@ -137,6 +137,7 @@ function edd_complete_purchase( $order_id, $new_status, $old_status ) {
 
 		// Clear the total earnings cache
 		delete_transient( 'edd_earnings_total' );
+		delete_transient( 'edd_earnings_total_without_tax' );
 
 		// Clear the This Month earnings (this_monththis_month is NOT a typo)
 		delete_transient( md5( 'edd_earnings_this_monththis_month' ) );

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -603,17 +603,19 @@ function edd_get_total_sales() {
  * Calculate the total earnings of the store.
  *
  * @since 1.2
- * @since 3.0 Refactored to work with new tables.
+ * @since 3.0   Refactored to work with new tables.
+ * @since 3.0.4 Added the $force argument, to force querying again.
  *
  * @param bool $include_taxes Whether taxes should be included. Default true.
+ * @param bool $force         If we should force a new calculation.
  * @return float $total Total earnings.
  */
-function edd_get_total_earnings( $include_taxes = true ) {
+function edd_get_total_earnings( $include_taxes = true, $force = true ) {
 	global $wpdb;
 
 	$key = $include_taxes ? 'edd_earnings_total' : 'edd_earnings_total_without_tax';
 
-	$total = get_transient( $key );
+	$total = $force ? false : get_transient( $key );
 
 	// If no total stored in the database, use old method of calculating total earnings.
 	if ( false === $total ) {
@@ -657,10 +659,8 @@ function edd_get_total_earnings( $include_taxes = true ) {
  * @return float $total Total earnings
  */
 function edd_increase_total_earnings( $amount = 0 ) {
-	$total  = floatval( edd_get_total_earnings() );
+	$total  = floatval( edd_get_total_earnings( true, true ) );
 	$total += floatval( $amount );
-
-	update_option( 'edd_earnings_total', $total );
 
 	return $total;
 }
@@ -674,14 +674,12 @@ function edd_increase_total_earnings( $amount = 0 ) {
  * @return float $total Total earnings.
  */
 function edd_decrease_total_earnings( $amount = 0 ) {
-	$total  = edd_get_total_earnings();
+	$total  = edd_get_total_earnings( true, true );
 	$total -= $amount;
 
 	if ( $total < 0 ) {
 		$total = 0;
 	}
-
-	update_option( 'edd_earnings_total', $total );
 
 	return $total;
 }

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -618,20 +618,21 @@ function edd_get_total_earnings( $include_taxes = true ) {
 	// If no total stored in the database, use old method of calculating total earnings.
 	if ( false === $total ) {
 
-		$stats = new EDD\Stats( array(
-			'output'        => 'typed',
-			'function'      => 'COUNT',
-			'exclude_taxes' => ! $include_taxes,
-			'revenue_type'  => 'net',
-		) );
+		$stats = new EDD\Stats();
 
-		$total = $stats->get_order_earnings();
+		$total = $stats->get_order_earnings(
+			array(
+				'output'        => 'typed',
+				'exclude_taxes' => ! $include_taxes,
+				'revenue_type'  => 'net',
+			)
+		);
 
 		// Cache results for 1 day. This cache is cleared automatically when a payment is made.
 		set_transient( $key, $total, 86400 );
 
 		// Store as an option for backwards compatibility.
-		update_option( $key, $total );
+		update_option( $key, $total, false );
 	} else {
 		// Always ensure that we're working with a float, since the transient comes back as a string.
 		$total = (float) $total;

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -619,7 +619,7 @@ function edd_get_total_earnings( $include_taxes = true ) {
 	if ( false === $total ) {
 
 		$stats = new EDD\Stats( array(
-			'output'        => 'raw',
+			'output'        => 'typed',
 			'function'      => 'COUNT',
 			'exclude_taxes' => ! $include_taxes,
 		) );
@@ -631,6 +631,9 @@ function edd_get_total_earnings( $include_taxes = true ) {
 
 		// Store as an option for backwards compatibility.
 		update_option( $key, $total );
+	} else {
+		// Always ensure that we're working with a float, since the transient comes back as a string.
+		$total = (float) $total;
 	}
 
 	// Don't ever show negative earnings.
@@ -638,7 +641,9 @@ function edd_get_total_earnings( $include_taxes = true ) {
 		$total = 0;
 	}
 
-	return apply_filters( 'edd_total_earnings', round( $total, edd_currency_decimal_filter() ) );
+	$total = edd_format_amount( $total, true, edd_get_currency(), 'typed' );
+
+	return apply_filters( 'edd_total_earnings', $total );
 }
 
 /**

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -622,6 +622,7 @@ function edd_get_total_earnings( $include_taxes = true ) {
 			'output'        => 'typed',
 			'function'      => 'COUNT',
 			'exclude_taxes' => ! $include_taxes,
+			'revenue_type'  => 'net',
 		) );
 
 		$total = $stats->get_order_earnings();

--- a/tests/orders/tests-edd-payment.php
+++ b/tests/orders/tests-edd-payment.php
@@ -481,7 +481,6 @@ class EDD_Payment_Tests extends \EDD_UnitTestCase {
 		$earnings = $download->earnings;
 		$sales    = $download->sales;
 
-		delete_option( 'edd_earnings_total' );
 		$store_earnings = edd_get_total_earnings();
 		$store_sales    = edd_get_total_sales();
 
@@ -708,7 +707,6 @@ class EDD_Payment_Tests extends \EDD_UnitTestCase {
 		$download_sales    = $download->sales;
 		$download_earnings = $download->earnings;
 
-		delete_option( 'edd_earnings_total' );
 		$store_earnings = edd_get_total_earnings();
 		$store_sales    = edd_get_total_sales();
 

--- a/tests/tests-formatting.php
+++ b/tests/tests-formatting.php
@@ -44,6 +44,20 @@ class Tests_Formatting extends EDD_UnitTestCase {
 		$this->assertEquals( '20 000.20', edd_format_amount( '20000.20' ) );
 	}
 
+	public function test_format_amount_typed() {
+		$this->assertEquals( 20000.20, edd_format_amount( '20000.20', true, '', 'typed' ) );
+
+		edd_update_option( 'thousands_separator', '.' );
+		edd_update_option( 'decimal_separator', ',' );
+
+		$this->assertEquals( 20000.20, edd_format_amount( '20000.20', true, '', 'typed' ) );
+
+		edd_update_option( 'thousands_separator', ' ' );
+		edd_update_option( 'decimal_separator', '.' );
+
+		$this->assertEquals( 20000.20, edd_format_amount( '20000.20', true, '', 'typed' ) );
+	}
+
 	public function test_currency_filter() {
 		$this->assertEquals( '&#36;20,000.20', edd_currency_filter( '20,000.20' ) );
 	}

--- a/uninstall.php
+++ b/uninstall.php
@@ -79,6 +79,7 @@ if( edd_get_option( 'uninstall_on_delete' ) ) {
 		'edd_completed_upgrades',
 		'edd_default_api_version',
 		'edd_earnings_total',
+		'edd_earnings_total_without_tax',
 		'edd_settings',
 		'edd_tracking_notice',
 		'edd_tax_rates',


### PR DESCRIPTION
Fixes #9361 

Proposed Changes:
1. Many changes but primarily removing calls to `get_sales/earnings_range` function calls in favor of using the stats class.
2. Stop using the old date formatting, and rely on the Store timezone adjusted UTC `date_created` column so the queries are correct when using dates and ranges.