### PR TITLE
Fix string that is not translatable #9365

### DIFF
--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -176,7 +176,7 @@ function edd_user_info_fields() {
 	$customer = array_map( 'sanitize_text_field', $customer );
 	?>
 	<fieldset id="edd_checkout_user_info">
-		<legend><?php echo apply_filters( 'edd_checkout_personal_info_text', esc_html__( 'Personal info', 'easy-digital-downloads' ) ); ?></legend>
+		<legend><?php echo apply_filters( 'edd_checkout_personal_info_text', esc_html_e( 'Personal info', 'easy-digital-downloads' ) ); ?></legend>
 		<?php do_action( 'edd_purchase_form_before_email' ); ?>
 		<p id="edd-email-wrap">
 			<label class="edd-label" for="edd-email">


### PR DESCRIPTION
Fixes #9365 

Proposed Changes:
1. Updates the 'Personal info' text on checkout to be run through gettext.