### PR TITLE
Removing old W3TC hooks for discounts when they were a post type #9375

### DIFF
--- a/includes/class-edd-cache-helper.php
+++ b/includes/class-edd-cache-helper.php
@@ -75,18 +75,6 @@ class EDD_Cache_Helper {
 				}
 			}
 		}
-
-		add_action( 'edd_pre_update_discount',         array( $this, 'w3tc_suspend_cache_addition_pre' ) );
-		add_action( 'edd_pre_insert_discount',         array( $this, 'w3tc_suspend_cache_addition_pre' ) );
-		add_action( 'edd_pre_delete_discount',         array( $this, 'w3tc_suspend_cache_addition_pre' ) );
-		add_action( 'edd_pre_update_discount_status',  array( $this, 'w3tc_suspend_cache_addition_pre' ) );
-		add_action( 'edd_pre_remove_cart_discount',    array( $this, 'w3tc_suspend_cache_addition_pre' ) );
-
-		add_action( 'edd_post_update_discount',        array( $this, 'w3tc_suspend_cache_addition_post' ) );
-		add_action( 'edd_post_insert_discount',        array( $this, 'w3tc_suspend_cache_addition_post' ) );
-		add_action( 'edd_post_delete_discount',        array( $this, 'w3tc_suspend_cache_addition_post' ) );
-		add_action( 'edd_post_update_discount_status', array( $this, 'w3tc_suspend_cache_addition_post' ) );
-		add_action( 'edd_post_remove_cart_discount',   array( $this, 'w3tc_suspend_cache_addition_post' ) );
 	}
 
 	/**
@@ -132,23 +120,5 @@ class EDD_Cache_Helper {
 			}
 		}
 
-	}
-
-	/**
-	 * Prevents W3TC from adding to the cache prior to modifying data.
-	 *
-	 * @since 1.7
-	 */
-	public function w3tc_suspend_cache_addition_pre() {
-		wp_suspend_cache_addition( true );
-	}
-
-	/**
-	 * Prevents W3TC from adding to the cache after modifying data.
-	 *
-	 * @since 1.7
-	 */
-	public function w3tc_suspend_cache_addition_post() {
-		wp_suspend_cache_addition();
 	}
 }

--- a/includes/class-edd-cache-helper.php
+++ b/includes/class-edd-cache-helper.php
@@ -121,4 +121,24 @@ class EDD_Cache_Helper {
 		}
 
 	}
+
+	/**
+	 * Prevents W3TC from adding to the cache prior to modifying data.
+	 *
+	 * @since 1.7
+	 * @since 3.0.4 Removed the cache suspend call.
+	 */
+	public function w3tc_suspend_cache_addition_pre() {
+		// This function does nothing as of EDD 3.0.4, it is only left here to prevent fatal errors in case it was used.
+	}
+
+	/**
+	 * Prevents W3TC from adding to the cache after modifying data.
+	 *
+	 * @since 1.7
+	 * @since 3.0.4 Removed the cache suspend call.
+	 */
+	public function w3tc_suspend_cache_addition_post() {
+		// This function does nothing as of EDD 3.0.4, it is only left here to prevent fatal errors in case it was used.
+	}
 }


### PR DESCRIPTION
Fixes #9375

Proposed Changes:
1. Removes hooks for discount changes to hook into W3TC