### PR TITLE
Increased default number of order items retrieved

### DIFF
--- a/includes/orders/classes/class-order.php
+++ b/includes/orders/classes/class-order.php
@@ -275,13 +275,7 @@ class Order extends Rows\Order {
 				'order'         => 'ASC',
 			) );
 		} elseif ( 'items' === $key && null === $this->items ) {
-			$this->items = edd_get_order_items( array(
-				'order_id'      => $this->id,
-				'orderby'       => 'cart_index',
-				'order'         => 'ASC',
-				'no_found_rows' => true,
-				'number'        => 100,
-			) );
+			$this->get_items();
 		}
 
 		return parent::__get( $key );
@@ -350,7 +344,7 @@ class Order extends Rows\Order {
 				'orderby'       => 'cart_index',
 				'order'         => 'ASC',
 				'no_found_rows' => true,
-				'number'        => 100,
+				'number'        => 200,
 			) );
 		}
 

--- a/includes/orders/classes/class-order.php
+++ b/includes/orders/classes/class-order.php
@@ -280,6 +280,7 @@ class Order extends Rows\Order {
 				'orderby'       => 'cart_index',
 				'order'         => 'ASC',
 				'no_found_rows' => true,
+				'number'        => 100,
 			) );
 		}
 
@@ -349,6 +350,7 @@ class Order extends Rows\Order {
 				'orderby'       => 'cart_index',
 				'order'         => 'ASC',
 				'no_found_rows' => true,
+				'number'        => 100,
 			) );
 		}
 

--- a/includes/orders/classes/class-order.php
+++ b/includes/orders/classes/class-order.php
@@ -274,7 +274,7 @@ class Order extends Rows\Order {
 				'no_found_rows' => true,
 				'order'         => 'ASC',
 			) );
-		} elseif ( 'items' === $key && null === $this->items ) {
+		} elseif ( 'items' === $key ) {
 			$this->get_items();
 		}
 

--- a/includes/orders/functions/items.php
+++ b/includes/orders/functions/items.php
@@ -169,7 +169,7 @@ function edd_get_order_items( $args = array() ) {
 
 	// Parse args
 	$r = wp_parse_args( $args, array(
-		'number' => 100,
+		'number' => 30,
 	) );
 
 	// Instantiate a query object

--- a/includes/orders/functions/items.php
+++ b/includes/orders/functions/items.php
@@ -169,7 +169,7 @@ function edd_get_order_items( $args = array() ) {
 
 	// Parse args
 	$r = wp_parse_args( $args, array(
-		'number' => 30,
+		'number' => 100,
 	) );
 
 	// Instantiate a query object


### PR DESCRIPTION
Fixes #9379

Proposed Changes:
I have set the default number of items retrieved to `100` as it feels enough.