### PR TITLE
Set ID on order address region text input

### DIFF
--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -481,7 +481,7 @@ function edd_order_details_addresses( $order ) {
 						); // WPCS: XSS ok.
 					} else {
 						?>
-						<input type="text" name="edd_order_address[region]" class="edd-form-group__input" value="<?php echo esc_attr( $address->region ); ?>" />
+						<input type="text" id="edd_order_address_region" name="edd_order_address[region]" class="edd-form-group__input" value="<?php echo esc_attr( $address->region ); ?>" />
 						<?php
 					}
 					?>


### PR DESCRIPTION
Proposed Changes:
1. When adding a new order on a store where the base country does not have an array of regions stored, so the text input is used instead of the select, adds the necessary `id` attribute for tax rate calculations.

This can be tested by setting your store's base country to a country which does not have regions stored. Norway works. With that set as your base country, set up a tax rate (I don't think the configuration for the rate matters actually) and then attempt to manually create an order which should have a tax rate assigned. In the `main` branch, it will not have a tax rate assigned.