### PR TITLE
Changed Earnings tile in reports to query data by gross statuses

### DIFF
--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -238,7 +238,7 @@ class Stats {
 		 * This may be overridden in $query parameters that get passed through.
 		 */
 		$this->query_vars['type']   = $this->get_revenue_type_order_types();
-		$this->query_vars['status'] = $this->get_revenue_type_statuses();
+		$this->query_vars['status'] = edd_get_gross_order_statuses();
 
 		/**
 		 * Filters Order statuses that should be included when calculating stats.


### PR DESCRIPTION
Fixes #9286

Proposed Changes:
1. We have decided that we will query `Earnings` tile in reports by gross statuses for now.
