### PR TITLE
Hour by Hour graph grouped only by hour, not day

### DIFF
--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -809,13 +809,17 @@ function get_groupby_date_string( $function = 'DATE', $column = 'date_created' )
 	$gmt_offset = $date->getOffset();
 
 	if ( empty( $gmt_offset ) ) {
-		$group_by_string = "{$function}({$column})";
 
-		// Always use YEAR and MONTH when grouping by MONTH.
-		if ( 'MONTH' === $function ) {
-			$group_by_string = "YEAR({$column}), MONTH({$column})";
-		} elseif ( 'HOUR' === $function ) {
-			$group_by_string = "DAY({$column}), HOUR({$column})";
+		switch ( $function ) {
+			case 'HOUR':
+				$group_by_string = "DAY({$column}), HOUR({$column})";
+				break;
+			case 'MONTH':
+				$group_by_string = "YEAR({$column}), MONTH({$column})";
+				break;
+			default:
+				$group_by_string = "{$function}({$column})";
+				break;
 		}
 
 		return $group_by_string;
@@ -828,14 +832,17 @@ function get_groupby_date_string( $function = 'DATE', $column = 'date_created' )
 
 	$formatted_offset = ! empty( $minutes ) ? "{$hours}:{$minutes}" : $hours . ':00';
 
-	$group_by_string = "{$function}(CONVERT_TZ({$column}, '+0:00', '{$math}{$formatted_offset}'))";
-	// Always use YEAR and MONTH when grouping by MONTH.
-	if ( 'MONTH' === $function ) {
-		$column_conversion = "CONVERT_TZ({$column}, '+0:00', '{$math}{$formatted_offset}')";
-		$group_by_string   = "YEAR({$column_conversion}), MONTH({$column_conversion})";
-	} elseif ( 'HOUR' === $function ) {
-		$column_conversion = "CONVERT_TZ({$column}, '+0:00', '{$math}{$formatted_offset}')";
-		$group_by_string   = "DAY({$column_conversion}), HOUR({$column_conversion})";
+	$column_conversion = "CONVERT_TZ({$column}, '+0:00', '{$math}{$formatted_offset}')";
+	switch ( $function ) {
+		case 'HOUR':
+			$group_by_string = "DAY({$column_conversion}), HOUR({$column_conversion})";
+			break;
+		case 'MONTH':
+			$group_by_string = "YEAR({$column_conversion}), MONTH({$column_conversion})";
+			break;
+		default:
+			$group_by_string = "{$function}({$column_conversion})";
+			break;
 	}
 
 	return $group_by_string;

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -814,6 +814,8 @@ function get_groupby_date_string( $function = 'DATE', $column = 'date_created' )
 		// Always use YEAR and MONTH when grouping by MONTH.
 		if ( 'MONTH' === $function ) {
 			$group_by_string = "YEAR({$column}), MONTH({$column})";
+		} elseif ( 'HOUR' === $function ) {
+			$group_by_string = "DAY({$column}), HOUR({$column})";
 		}
 
 		return $group_by_string;
@@ -831,6 +833,9 @@ function get_groupby_date_string( $function = 'DATE', $column = 'date_created' )
 	if ( 'MONTH' === $function ) {
 		$column_conversion = "CONVERT_TZ({$column}, '+0:00', '{$math}{$formatted_offset}')";
 		$group_by_string   = "YEAR({$column_conversion}), MONTH({$column_conversion})";
+	} elseif ( 'HOUR' === $function ) {
+		$column_conversion = "CONVERT_TZ({$column}, '+0:00', '{$math}{$formatted_offset}')";
+		$group_by_string   = "DAY({$column_conversion}), HOUR({$column_conversion})";
 	}
 
 	return $group_by_string;


### PR DESCRIPTION
Fixes #

Proposed Changes:
1. If 'HOUR' is used as the grouping, ensures that we group by 'hour' and 'day' to fix a 2 day hour by hour report.

Two replicate, select a graph that reports hour by hour, like a 2 day span.

With Changes:
![image](https://user-images.githubusercontent.com/1390124/186259471-a421951e-cb25-4d74-82e5-4b74fa70d932.png)

Without Changes:
<img width="2164" alt="Screen Shot 2022-08-23 at 1 30 07 PM" src="https://user-images.githubusercontent.com/1390124/186259565-410ac197-82a8-4b8e-b565-59c70db76dba.png">

