### PR TITLE
Revert new customer attachment, and improve customer->attach_payment to always run the hooks #9344

### DIFF
--- a/includes/class-edd-customer.php
+++ b/includes/class-edd-customer.php
@@ -682,10 +682,10 @@ class EDD_Customer extends \EDD\Database\Rows\Customer {
 
 		do_action( 'edd_customer_pre_attach_payment', $order->id, $this->id, $this );
 
-		$success = false;
+		$success = (int) $order->customer_id === (int) $this->id;
 
 		// Update the order if it isn't already attached.
-		if ( (int) $order->customer_id !== (int) $this->id ) {
+		if ( ! $success ) {
 			// Update the order.
 			$success = (bool) edd_update_order(
 				$order_id,

--- a/includes/class-edd-customer.php
+++ b/includes/class-edd-customer.php
@@ -660,40 +660,43 @@ class EDD_Customer extends \EDD\Database\Rows\Customer {
 	 *
 	 * @since 2.3
 	 *
-	 * @param int  $payment_id   The payment ID to attach to the customer.
+	 * @param int  $order_id     The Order ID to attach to the customer.
 	 * @param bool $update_stats For backwards compatibility, if we should increase the stats or not.
 	 *
 	 * @return bool True if the attachment was successfully, false otherwise.
 	 */
-	public function attach_payment( $payment_id = 0, $update_stats = true ) {
+	public function attach_payment( $order_id = 0, $update_stats = true ) {
 
-		// Bail if no payment ID
-		if ( empty( $payment_id ) ) {
+		// Bail if no payment ID.
+		if ( empty( $order_id ) ) {
 			return false;
 		}
 
-		// Get payment
-		$order = edd_get_order( $payment_id );
+		// Get order.
+		$order = edd_get_order( $order_id );
 
-		// Bail if payment does not exist
+		// Bail if payment does not exist.
 		if ( empty( $order ) ) {
 			return false;
 		}
 
-		// Bail if already attached
-		if ( (int) $order->customer_id === (int) $this->id ) {
-			return true;
-		}
-
 		do_action( 'edd_customer_pre_attach_payment', $order->id, $this->id, $this );
 
-		// Update the order
-		$success = (bool) edd_update_order( $payment_id, array(
-			'customer_id' => $this->id,
-			'email'       => $this->email
-		) );
+		$success = false;
 
-		// Maybe update stats
+		// Update the order if it isn't already attached.
+		if ( (int) $order->customer_id !== (int) $this->id ) {
+			// Update the order.
+			$success = (bool) edd_update_order(
+				$order_id,
+				array(
+					'customer_id' => $this->id,
+					'email'       => $this->email,
+				)
+			);
+		}
+
+		// Maybe update stats.
 		if ( ! empty( $success ) && ! empty( $update_stats ) ) {
 			$this->recalculate_stats();
 		}


### PR DESCRIPTION
Fixes #9344 

Proposed Changes:
1. Reverts back to the `edd_customer_post_attach_payment` hook.
2. Adjusted the `EDD_Customer->attach_payment` method to run the hooks even an order is already attached.

This will need testing with and without Auto Register.