### PR TITLE
Allow using a constant EDD_TEST_MODE to force test_mode to true #7098

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1178,7 +1178,7 @@ function edd_get_registered_settings() {
 		}
 
 		// If the constant is defined as true for EDD_TEST_MODE do not allow changing the Test Mode setting.
-		if ( defined( 'EDD_TEST_MODE' ) && true === EDD_TEST_MODE ) {
+		if ( edd_is_test_mode_forced() ) {
 			$edd_settings['gateways']['main']['test_mode'] = array_merge(
 				array(
 					'options'       => array(
@@ -1186,7 +1186,7 @@ function edd_get_registered_settings() {
 						'readonly' => true,
 					),
 					'tooltip_title' => __( 'Forced Test Mode', 'easy-digital-downloads' ),
-					'tooltip_desc'  => __( 'You currently cannot modify the Test Mode setting, as the \'EDD_TEST_MODE\' constant has been defined as \'true\'.', 'easy-digital-downloads' ),
+					'tooltip_desc'  => __( 'You currently cannot modify the Test Mode setting, as the \'EDD_TEST_MODE\' constant has been defined as \'true\' or the edd_is_test_mode filter is being forced to \'true\'.', 'easy-digital-downloads' ),
 				),
 				$edd_settings['gateways']['main']['test_mode'],
 			);
@@ -3025,11 +3025,33 @@ add_filter( 'edd_after_setting_output', 'edd_add_setting_tooltip', 10, 2 );
  * @param bool   $default The default setting, which is 'false' for test_mode.
  */
 function edd_filter_test_mode_option( $value, $key, $default ) {
-	if ( defined( 'EDD_TEST_MODE' ) && true === EDD_TEST_MODE ) {
+	if ( edd_is_test_mode_forced() ) {
 		$value = true;
 	}
 
 	return $value;
 }
 add_filter( 'edd_get_option_test_mode', 'edd_filter_test_mode_option', 10, 3 );
+
+/**
+ * Determine if test mode is being forced to true.
+ *
+ * Using the EDD_TEST_MODE and the edd_is_test_mode filter, determine if the value of true
+ * is being forced for test_mode so we can properly alter the setting for it.
+ *
+ * @since 3.1
+ *
+ * @return bool If test_mode is being forced or not.
+ */
+function edd_is_test_mode_forced() {
+	if ( defined( 'EDD_TEST_MODE' ) && true === EDD_TEST_MODE ) {
+		return true;
+	}
+
+	if ( false !== has_filter( 'edd_is_test_mode', '__return_true' ) ) {
+		return true;
+	}
+
+	return false;
+}
 

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1177,7 +1177,7 @@ function edd_get_registered_settings() {
 			);
 		}
 
-		// If the constant is defined as true for EDD_TEST_MODE do not allow changing the Test Mode setting.
+		// If test_mode is being forced to true, alter the setting so it cannot be modified.
 		if ( edd_is_test_mode_forced() ) {
 			$edd_settings['gateways']['main']['test_mode'] = array_merge(
 				array(
@@ -3016,7 +3016,7 @@ add_filter( 'edd_after_setting_output', 'edd_add_setting_tooltip', 10, 2 );
  * Filters the edd_get_option call for test_mode.
  *
  * This allows us to ensure that calls directly to edd_get_option respect the constant
- * in addition to the edd_is_test_mode() function call.
+ * in addition to the edd_is_test_mode() function call and included filter.
  *
  * @since 3.1
  *

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1188,7 +1188,7 @@ function edd_get_registered_settings() {
 					'tooltip_title' => __( 'Forced Test Mode', 'easy-digital-downloads' ),
 					'tooltip_desc'  => __( 'You currently cannot modify the Test Mode setting, as the \'EDD_TEST_MODE\' constant has been defined as \'true\' or the edd_is_test_mode filter is being forced to \'true\'.', 'easy-digital-downloads' ),
 				),
-				$edd_settings['gateways']['main']['test_mode'],
+				$edd_settings['gateways']['main']['test_mode']
 			);
 		}
 

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1177,6 +1177,21 @@ function edd_get_registered_settings() {
 			);
 		}
 
+		// If the constant is defined as true for EDD_TEST_MODE do not allow changing the Test Mode setting.
+		if ( defined( 'EDD_TEST_MODE' ) && true === EDD_TEST_MODE ) {
+			$edd_settings['gateways']['main']['test_mode'] = array_merge(
+				array(
+					'options'       => array(
+						'disabled' => true,
+						'readonly' => true,
+					),
+					'tooltip_title' => __( 'Forced Test Mode', 'easy-digital-downloads' ),
+					'tooltip_desc'  => __( 'You currently cannot modify the Test Mode setting, as the \'EDD_TEST_MODE\' constant has been defined as \'true\'.', 'easy-digital-downloads' ),
+				),
+				$edd_settings['gateways']['main']['test_mode'],
+			);
+		}
+
 		// Allow registered settings to surface the deprecated "Styles" tab.
 		if ( has_filter( 'edd_settings_styles' ) ) {
 			$edd_settings['styles'] = edd_apply_filters_deprecated(
@@ -1817,6 +1832,11 @@ function edd_checkbox_callback( $args ) {
  */
 function edd_checkbox_description_callback( $args ) {
 	$edd_option = edd_get_option( $args['id'] );
+
+	// Allow a setting or filter to override what the found value is.
+	if ( isset( $args['current'] ) ) {
+		$edd_option = $args['current'];
+	}
 
 	if ( isset( $args['faux'] ) && true === $args['faux'] ) {
 		$name = '';
@@ -2991,3 +3011,25 @@ function edd_add_setting_tooltip( $html = '', $args = array() ) {
 	return $html;
 }
 add_filter( 'edd_after_setting_output', 'edd_add_setting_tooltip', 10, 2 );
+
+/**
+ * Filters the edd_get_option call for test_mode.
+ *
+ * This allows us to ensure that calls directly to edd_get_option respect the constant
+ * in addition to the edd_is_test_mode() function call.
+ *
+ * @since 3.1
+ *
+ * @param bool   $value   If test_mode is enabled in the settings.
+ * @param string $key     The key of the setting, should be test_mode.
+ * @param bool   $default The default setting, which is 'false' for test_mode.
+ */
+function edd_filter_test_mode_option( $value, $key, $default ) {
+	if ( defined( 'EDD_TEST_MODE' ) && true === EDD_TEST_MODE ) {
+		$value = true;
+	}
+
+	return $value;
+}
+add_filter( 'edd_get_option_test_mode', 'edd_filter_test_mode_option', 10, 3 );
+

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -60,7 +60,7 @@ function edd_is_test_mode() {
 	$ret = edd_get_option( 'test_mode', false );
 
 	// Override any setting with the constant.
-	if ( defined( 'EDD_TEST_MODE') && true === EDD_TEST_MODE ) {
+	if ( edd_is_test_mode_forced() ) {
 		$ret = true;
 	}
 

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -58,6 +58,13 @@ function edd_get_admin_url( $args = array() ) {
  */
 function edd_is_test_mode() {
 	$ret = edd_get_option( 'test_mode', false );
+
+	// Override any setting with the constant.
+	if ( defined( 'EDD_TEST_MODE') && true === EDD_TEST_MODE ) {
+		$ret = true;
+	}
+
+	// At the end of the day, the filter still has the final say.
 	return (bool) apply_filters( 'edd_is_test_mode', $ret );
 }
 


### PR DESCRIPTION
Fixes #7098
Fixes #6712 

Proposed Changes:
1. Adds support for the `EDD_TEST_MODE` constant.
2. If `true` is the value, puts the store in test mode, disables the setting and always returns `true` for calls to `edd_is_test_mode()` and `edd_get_option( 'test_mode' )`
3. Adds a new `edd_is_test_mode_forced()` which uses the constant and the filter `edd_is_test_mode` (when using `__return_true`) to determine if we're forcing test mode so we can set the setting to disabled and readonly.