### PR TITLE
Adding filters that can allow disabling logging #8450

### DIFF
--- a/includes/logs/api-request-log/functions.php
+++ b/includes/logs/api-request-log/functions.php
@@ -65,7 +65,6 @@ function edd_add_api_request_log( $data = array() ) {
 	$should_record_log = apply_filters( 'edd_should_log_api_request', true, $data );
 
 	if ( false === $should_record_log ) {
-		edd_debug_log( 'Did not log api request due to filter', true );
 		return false;
 	}
 

--- a/includes/logs/api-request-log/functions.php
+++ b/includes/logs/api-request-log/functions.php
@@ -54,7 +54,22 @@ function edd_add_api_request_log( $data = array() ) {
 		return false;
 	}
 
-	// Instantiate a query object
+	/**
+	 * Allow the ability to disable an API Request Log from being inserted.
+	 *
+	 * @since 3.1
+	 *
+	 * @param bool  $should_record_log If this API reqeust should be logged.
+	 * @param array $data              The data to be logged.
+	 */
+	$should_record_log = apply_filters( 'edd_should_log_api_request', true, $data );
+
+	if ( false === $should_record_log ) {
+		edd_debug_log( 'Did not log api request due to filter', true );
+		return false;
+	}
+
+	// Instantiate a query object.
 	$api_request_logs = new EDD\Database\Queries\Log_Api_Request();
 
 	return $api_request_logs->add_item( $data );

--- a/includes/logs/file-download-log/functions.php
+++ b/includes/logs/file-download-log/functions.php
@@ -55,6 +55,21 @@ function edd_add_file_download_log( $data = array() ) {
 		return false;
 	}
 
+	/**
+	 * Allow the ability to disable a File Download Log being inserted.
+	 *
+	 * @since 3.1
+	 *
+	 * @param bool  $should_record_log If this file download should be logged.
+	 * @param array $data              The data to be logged.
+	 */
+	$should_record_log = apply_filters( 'edd_should_log_file_download', true, $data );
+
+	if ( false === $should_record_log ) {
+		edd_debug_log( 'Did not log file download due to filter', true );
+		return false;
+	}
+
 	$file_download_logs = new EDD\Database\Queries\Log_File_Download();
 
 	return $file_download_logs->add_item( $data );

--- a/includes/logs/file-download-log/functions.php
+++ b/includes/logs/file-download-log/functions.php
@@ -66,7 +66,6 @@ function edd_add_file_download_log( $data = array() ) {
 	$should_record_log = apply_filters( 'edd_should_log_file_download', true, $data );
 
 	if ( false === $should_record_log ) {
-		edd_debug_log( 'Did not log file download due to filter', true );
 		return false;
 	}
 

--- a/includes/logs/log/functions.php
+++ b/includes/logs/log/functions.php
@@ -52,7 +52,7 @@ function edd_add_log( $data = array() ) {
 	// inserted into the database.
 	if ( empty( $data['object_type'] ) ) {
 		// If the object_type is set to null, check the value of the object_id.
-		if ( is_null( $data['object_type'] ) ) {
+		if ( isset( $data['object_type'] ) && is_null( $data['object_type'] ) ) {
 			// If the object_id is not empty but the object_type is, fail this log attempt.
 			if ( ! empty( $data['object_id'] ) ) {
 				return false;
@@ -63,6 +63,7 @@ function edd_add_log( $data = array() ) {
 		}
 	}
 
+	$object_type_for_filter = ! empty( $data['object_type'] ) ? $data['object_type'] : 'generic';
 	/**
 	 * Allow the ability to disable a generic log entry by object_type.
 	 *
@@ -78,7 +79,7 @@ function edd_add_log( $data = array() ) {
 	 * @param bool  $should_record_log If this log should be inserted
 	 * @param array $data              The data to be logged.
 	 */
-	$should_record_log = apply_filters( "edd_should_log_{$data['object_type']}", true, $data );
+	$should_record_log = apply_filters( "edd_should_log_{$object_type_for_filter}", true, $data );
 
 	if ( false === $should_record_log ) {
 		return false;

--- a/includes/logs/log/functions.php
+++ b/includes/logs/log/functions.php
@@ -51,9 +51,9 @@ function edd_add_log( $data = array() ) {
 	// An object type must be supplied for every log that is
 	// inserted into the database.
 	if ( empty( $data['object_type'] ) ) {
-		// If the object_type is set to null, check the value of the object_id.
-		if ( isset( $data['object_type'] ) && is_null( $data['object_type'] ) ) {
-			// If the object_id is not empty but the object_type is, fail this log attempt.
+		// Verify that we do have an object_type before checking it further.
+		if ( array_key_exists( 'object_type', $data ) && is_null( $data['object_type'] ) ) {
+			// If the object_id is not empty but the object_type is null, fail this log attempt.
 			if ( ! empty( $data['object_id'] ) ) {
 				return false;
 			}

--- a/includes/logs/log/functions.php
+++ b/includes/logs/log/functions.php
@@ -63,6 +63,28 @@ function edd_add_log( $data = array() ) {
 		}
 	}
 
+	/**
+	 * Allow the ability to disable a generic log entry by object_type.
+	 *
+	 * Based on the object type, allows developers to disable the insertion of a log.
+	 *
+	 * Example:
+	 * add_filter( 'edd_should_log_gateway_error', '__return_false' )
+	 *
+	 * You can find a list of the logs object types in the edd_logs table.
+	 *
+	 * @since 3.1
+	 *
+	 * @param bool  $should_record_log If this log should be inserted
+	 * @param array $data              The data to be logged.
+	 */
+	$should_record_log = apply_filters( "edd_should_log_{$data['object_type']}", true, $data );
+
+	if ( false === $should_record_log ) {
+		edd_debug_log( 'Did not log due to filter', true );
+		return false;
+	}
+
 	// Instantiate a query object.
 	$logs = new EDD\Database\Queries\Log();
 

--- a/includes/logs/log/functions.php
+++ b/includes/logs/log/functions.php
@@ -81,7 +81,6 @@ function edd_add_log( $data = array() ) {
 	$should_record_log = apply_filters( "edd_should_log_{$data['object_type']}", true, $data );
 
 	if ( false === $should_record_log ) {
-		edd_debug_log( 'Did not log due to filter', true );
 		return false;
 	}
 

--- a/tests/tests-logging.php
+++ b/tests/tests-logging.php
@@ -126,7 +126,7 @@ class Tests_Logging extends EDD_UnitTestCase {
 	}
 
 	/**
-	 * @covers edd_record_gateway_error()
+	 * @covers edd_add_log()
 	 */
 	public function test_edd_add_log_with_null_type_and_no_id() {
 


### PR DESCRIPTION
Fixes #8450 

Proposed Changes:
1. Adds 3 new filters to disable logging
`edd_should_log_{$data['object_type']}`
`edd_should_log_file_download`
`edd_should_log_api_request`

Example filters:
```
// Disabling an entry in the generic logs table. Replace {gateway_error} with the `object_type` being logged.
add_filter( 'edd_should_log_gateway_error', '__return_false' );

// Specific log type disabling.
add_filter( 'edd_should_log_file_download', '__return_false' );
add_filter( 'edd_should_log_api_request', '__return_false' );
```