### PR TITLE
Move download recalculations to after payment actions hook

### DIFF
--- a/includes/orders/functions/transitions.php
+++ b/includes/orders/functions/transitions.php
@@ -64,13 +64,13 @@ add_action( 'edd_refund_order', 'edd_recalculate_order_downloads' );
  * @return void
  */
 function edd_recalculate_order_downloads( $order_id ) {
-	$order_items = edd_get_order_items(
+	$order_item_product_ids = edd_get_order_items(
 		array(
 			'order_id' => $order_id,
 			'fields'   => 'product_id',
 		)
 	);
-	foreach ( $order_items as $order_item ) {
-		edd_recalculate_download_sales_earnings( $order_item );
+	foreach ( $order_item_product_ids as $product_id ) {
+		edd_recalculate_download_sales_earnings( $product_id );
 	}
 }

--- a/tests/downloads/tests-download-sales-earnings.php
+++ b/tests/downloads/tests-download-sales-earnings.php
@@ -60,6 +60,7 @@ class Test_Download_Sales_Earnings extends \EDD_UnitTestCase {
 				'quantity'     => 1,
 			)
 		);
+		do_action( 'edd_after_payment_actions', $order_id );
 
 		$download = edd_get_download( $this->simple_download->ID );
 		$this->assertEquals( get_post_meta( $download->ID, '_edd_download_gross_sales', true ), $download->get_sales() );
@@ -96,6 +97,7 @@ class Test_Download_Sales_Earnings extends \EDD_UnitTestCase {
 				'quantity'     => 1,
 			)
 		);
+		do_action( 'edd_after_payment_actions', $order_id );
 
 		$download = edd_get_download( $this->simple_download->ID );
 		$this->assertEquals( get_post_meta( $download->ID, '_edd_download_gross_earnings', true ), $download->get_earnings() );
@@ -373,6 +375,7 @@ class Test_Download_Sales_Earnings extends \EDD_UnitTestCase {
 				'discount'     => 5,
 			)
 		);
+		do_action( 'edd_after_payment_actions', $order_id );
 
 		$download = edd_get_download( $this->simple_download->ID );
 		$this->assertEquals( 5, get_post_meta( $download->ID, '_edd_download_gross_earnings', true ) - $download->earnings );
@@ -418,6 +421,7 @@ class Test_Download_Sales_Earnings extends \EDD_UnitTestCase {
 				'total'       => 5,
 			)
 		);
+		do_action( 'edd_after_payment_actions', $order_id );
 
 		$download = edd_get_download( $this->simple_download->ID );
 		$this->assertEquals( $download->earnings, get_post_meta( $download->ID, '_edd_download_gross_earnings', true ) );
@@ -464,7 +468,7 @@ class Test_Download_Sales_Earnings extends \EDD_UnitTestCase {
 			)
 		);
 
-		// edd_update_order_item( $order_item_id, array( 'status' => 'complete' ) );
+		do_action( 'edd_after_payment_actions', $order_id );
 
 		$download = edd_get_download( $this->simple_download->ID );
 		$this->assertEquals( 5, get_post_meta( $download->ID, '_edd_download_gross_earnings', true ) - $download->earnings );


### PR DESCRIPTION
Proposed Changes:
1. Instead of recalculating download sales and earnings on the Berlin transition hooks, use the `edd_after_payment_actions` hook to have the recalculations run outside of the actual purchase transaction.