### PR TITLE
Ensure discounts not found return no orders in admin search

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -1009,6 +1009,9 @@ class EDD_Payment_History_Table extends List_Table {
 			$discount = edd_get_discount_by_code( trim( str_replace( 'discount:', '', $search ) ) );
 			if ( ! empty( $discount->id ) ) {
 				$args['discount_id'] = $discount->id;
+			} else {
+				// If no discount object is found, we force the results to be empty.
+				$args['id__in'] = array( null );
 			}
 
 			return $args;


### PR DESCRIPTION
Fixes #7364

Proposed Changes:
1. When searching the orders table for a discount code which doesn't exist, this sets the `id__in` parameter to a null array, similar to the customer search. This is a bit of a workaround--the customer search works this way because the customer ID is a property on the order, but the discount is not.
