### PR TITLE
Do not remove spaces from user logins as they are allowed by WP Core #9411

### DIFF
--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -596,9 +596,9 @@ function edd_purchase_form_validate_new_user() {
 		? sanitize_text_field( $_POST['edd_last'] )
 		: '';
 
-	// Sanitize user login (not strict-mode for back-compat)
-	$user_login   = isset( $_POST['edd_user_login'] )
-		? preg_replace( '/\s+/', '', sanitize_user( $_POST['edd_user_login'], false ) )
+	// Sanitize user login.
+	$user_login = isset( $_POST['edd_user_login'] )
+		? sanitize_user( $_POST['edd_user_login'] )
 		: false;
 
 	// Sanitize email address (allowed formatting only)


### PR DESCRIPTION
Fixes #9411 

Proposed Changes:
1. Removes the `preg_replace` while sanitizing the username supplied at checkout.

To Test:
1. Enable registration at checkout.
2. Provide the username of "Test User"
3. The ` ` character should be retained and is `Test User`.

As a note the `sanitize_user` function we are calling from WP Core does remove `multiple spaces` so something like `Test  User` will become `Test User`. This is expected and is fine as it follows WP Core standards.