### PR TITLE
Update object ID column for EDD logging class

### DIFF
--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -424,7 +424,7 @@ class EDD_Logging {
 	 */
 	public function get_log_count( $object_id = 0, $type = null, $meta_query = null, $date_query = null ) {
 		$r = array(
-			'object_id' => $object_id,
+			$this->get_object_id_column_name_for_type( $type ) => $object_id,
 		);
 
 		if ( ! empty( $type ) && $this->valid_type( $type ) ) {
@@ -462,7 +462,7 @@ class EDD_Logging {
 	 */
 	public function delete_logs( $object_id = 0, $type = null, $meta_query = null ) {
 		$r = array(
-			'object_id' => $object_id,
+			$this->get_object_id_column_name_for_type( $type ) => $object_id,
 		);
 
 		if ( ! empty( $type ) && $this->valid_type( $type ) ) {
@@ -553,11 +553,8 @@ class EDD_Logging {
 
 		// Back-compat for post_parent.
 		if ( ! empty( $r['post_parent'] ) ) {
-			if ( ! empty( $r['log_type'] && 'file_download' === $r['log_type'] ) ) {
-				$r['product_id'] = $r['post_parent'];
-			} else {
-				$r['object_id'] = $r['post_parent'];
-			}
+			$type                                        = ! empty( $r['log_type'] ) ? $r['log_type'] : '';
+			$r[ $this->get_object_id_column_name_for_type( $type ) ] = $r['post_parent'];
 		}
 
 		// Back compat for posts_per_page
@@ -581,6 +578,32 @@ class EDD_Logging {
 
 		// Return parsed args
 		return $r;
+	}
+
+	/**
+	 * Gets the object ID column name based on the log type.
+	 *
+	 * @since 3.1
+	 * @param string $type The log type.
+	 * @return string      The column name to query for the object ID.
+	 */
+	private function get_object_id_column_name_for_type( $type = '' ) {
+
+		switch ( $type ) {
+			case 'file_download':
+				$object_id = 'product_id';
+				break;
+
+			case 'api_request':
+				$object_id = 'user_id';
+				break;
+
+			default:
+				$object_id = 'object_id';
+				break;
+		}
+
+		return $object_id;
 	}
 
 	/** File System ***********************************************************/

--- a/tests/tests-logging.php
+++ b/tests/tests-logging.php
@@ -89,6 +89,22 @@ class Tests_Logging extends EDD_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::get_log_count()
+	 */
+	public function test_get_log_count_file_downloads() {
+		$file_download_log = self::$object->insert_log(
+			array(
+				'log_type'    => 'file_download',
+				'post_parent' => 1,
+			),
+			array(
+				'payment_id' => 1234,
+			)
+		);
+		$this->assertSame( 1, self::$object->get_log_count( 1, 'file_download' ) );
+	}
+
+	/**
 	 * @covers ::delete_logs()
 	 */
 	public function test_delete_logs() {


### PR DESCRIPTION
Fixes #9313

Proposed Changes:
1. Creates a private method `get_object_id_column_name_for_type` to get the correct "object ID" column for a given log type:
    - 'object_id` as a default
    - `product_id` for file downloads
    - `user_id` for API requests ... not sure on this one as it looks like API requests never assigned a post parent to that log type, so I'm not sure there was a way to actually query API logs in this manner. But user ID seemed like a reasonable option and object ID is certainly invalid.
2. Updates `get_log_count`, `delete_logs`, and `parse_args` methods to use the new helper method.
3. Adds a unit test to add a file download log and count it using the original `get_log_count` method.

You can test by generating some file download logs (CLI command: `wp edd download_logs create --number=10`) and then using the code in the original issue to query for logs.
