### PR TITLE
Set autocomplete to 'off' on gateway selector so Firefox recovers from page refresh #9408

### DIFF
--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -632,7 +632,7 @@ function edd_payment_mode_select() {
 						$nonce         = ' data-' . esc_attr( $gateway_id ) . '-nonce="' . wp_create_nonce( 'edd-gateway-selected-' . esc_attr( $gateway_id ) ) .'"';
 
 						echo '<label for="edd-gateway-' . esc_attr( $gateway_id ) . '" class="edd-gateway-option ' . esc_attr( $checked_class ) . '" id="edd-gateway-option-' . esc_attr( $gateway_id ) . '">';
-							echo '<input type="radio" name="payment-mode" class="edd-gateway" id="edd-gateway-' . esc_attr( $gateway_id ) . '" value="' . esc_attr( $gateway_id ) . '"' . $checked . $nonce . '>' . esc_html( $label );
+							echo '<input autocomplete="off" type="radio" name="payment-mode" class="edd-gateway" id="edd-gateway-' . esc_attr( $gateway_id ) . '" value="' . esc_attr( $gateway_id ) . '"' . $checked . $nonce . '>' . esc_html( $label );
 						echo '</label>';
 					}
 


### PR DESCRIPTION
Fixes #9408

Proposed Changes:
1. Adds `autocomplete="off"` to the gateway selector inputs, to avoid a refresh in Firefox putting the checkout in an unrecoverable state.


Steps to reproduce and test:
1. Use Firefox
2. Have a store with multiple gateways active.
3. Add a product to the cart.
4. Select the non-default gateway
5. Refresh the page (with ctrl+r, F5, or the refresh button - depending on your OS)
6. Replicate and Verify Fix
6a. On `main` branch, notice that the default gateway fields are shown, but the radio is still set to the 'selected' gateway from before the refresh.
6b. On `issue/9408` notice that both the radio selector and the payment gateway fields have reset to the default state of the checkout.