### PR TITLE
Update payment methods for incomplete data

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -957,6 +957,7 @@ class EDD_Payment {
 							'discount'     => $item['discount'],
 							'tax'          => $item['tax'],
 							'total'        => $item['price'],
+							'status'       => ! empty( $item['status'] ) ? $item['status'] : $this->status,
 						) );
 					}
 				}
@@ -1035,6 +1036,7 @@ class EDD_Payment {
 			'discount'   => 0,
 			'tax'        => 0.00,
 			'fees'       => array(),
+			'status'     => $this->status,
 		);
 
 		$args = wp_parse_args( apply_filters( 'edd_payment_add_download_args', $args, $download->ID ), $defaults );
@@ -2347,6 +2349,7 @@ class EDD_Payment {
 								'discount'     => $item['discount'],
 								'tax'          => $item['tax'],
 								'total'        => $item['price'],
+								'status'       => ! empty( $item['status'] ) ? $item->status : $this->status,
 							) );
 
 							$new_tax += $item['tax'];


### PR DESCRIPTION
Fixes #9157

Proposed Changes:
1. Updates the `EDD_Payment` class to allow added downloads to set or inherit the order/payment status (this covers adding a payment and saving it directly as `complete` instead of as `pending` first).
2. Updates `edd_build_order` to account for missing/incomplete data.
