### PR TITLE
When saving  the bundle product conditions, ensure that the array keys are re-indexed, starting at 1 #9343

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -184,6 +184,22 @@ function edd_sanitize_bundled_products_save( $products = array() ) {
 add_filter( 'edd_metabox_save__edd_bundled_products', 'edd_sanitize_bundled_products_save' );
 
 /**
+ * Sanitize bundled products conditions on save
+ *
+ * @since 3.1
+ *
+ * @param array $bundled_products_conditions
+ * @return array
+ */
+function edd_sanitize_bundled_products_conditions_save( $bundled_products_conditions = array() ) {
+	return array_combine(
+		range( 1, count( $bundled_products_conditions ) ),
+		array_values( $bundled_products_conditions )
+	);
+}
+add_filter( 'edd_metabox_save__edd_bundled_products_conditions', 'edd_sanitize_bundled_products_conditions_save' );
+
+/**
  * Don't save blank rows.
  *
  * When saving, check the price and file table for blank rows.

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -184,22 +184,6 @@ function edd_sanitize_bundled_products_save( $products = array() ) {
 add_filter( 'edd_metabox_save__edd_bundled_products', 'edd_sanitize_bundled_products_save' );
 
 /**
- * Sanitize bundled products conditions on save.
- *
- * @since 3.1
- *
- * @param array $bundled_products_conditions
- * @return array
- */
-function edd_sanitize_bundled_products_conditions_save( $bundled_products_conditions = array() ) {
-	return array_combine(
-		range( 1, count( $bundled_products_conditions ) ),
-		array_values( $bundled_products_conditions )
-	);
-}
-add_filter( 'edd_metabox_save__edd_bundled_products_conditions', 'edd_sanitize_bundled_products_conditions_save' );
-
-/**
  * Don't save blank rows.
  *
  * When saving, check the price and file table for blank rows.
@@ -632,7 +616,7 @@ function edd_render_products_field( $post_id ) {
 										<?php
 										echo EDD()->html->product_dropdown(
 											array(
-												'name'                 => '_edd_bundled_products[]',
+												'name'                 => '_edd_bundled_products[' . $index . ']',
 												'id'                   => 'edd_bundled_products_' . esc_attr( $index ),
 												'selected'             => $product,
 												'multiple'             => false,
@@ -666,7 +650,7 @@ function edd_render_products_field( $post_id ) {
 											$selected = isset( $price_assignments[ $index ] ) ? $price_assignments[ $index ] : null;
 
 											echo EDD()->html->select( array(
-												'name'             => '_edd_bundled_products_conditions['. $index .']',
+												'name'             => '_edd_bundled_products_conditions[' . $index . ']',
 												'id'               => 'edd_bundled_products_conditions_'. esc_attr( $index ),
 												'class'            => 'edd_repeatable_condition_field',
 												'options'          => $options,
@@ -702,7 +686,7 @@ function edd_render_products_field( $post_id ) {
 									<div class="edd-form-group__control">
 									<?php
 									echo EDD()->html->product_dropdown( array(
-										'name'                 => '_edd_bundled_products[]',
+										'name'                 => '_edd_bundled_products[1]',
 										'id'                   => 'edd_bundled_products_1',
 										'multiple'             => false,
 										'chosen'               => true,

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -179,7 +179,12 @@ function edd_sanitize_bundled_products_save( $products = array() ) {
 		}
 	}
 
-	return array_values( array_unique( $products ) );
+	$products = array_unique( $products );
+
+	return array_combine(
+		range( 1, count( $products ) ),
+		array_values( $products )
+	);
 }
 add_filter( 'edd_metabox_save__edd_bundled_products', 'edd_sanitize_bundled_products_save' );
 

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -70,7 +70,7 @@ function edd_download_metabox_fields() {
 		'_edd_quantities_disabled',
 		'edd_product_notes',
 		'_edd_default_price_id',
-		'_edd_bundled_products_conditions'
+		'_edd_bundled_products_conditions',
 	);
 
 	if ( current_user_can( 'manage_shop_settings' ) ) {
@@ -182,6 +182,22 @@ function edd_sanitize_bundled_products_save( $products = array() ) {
 	return array_values( array_unique( $products ) );
 }
 add_filter( 'edd_metabox_save__edd_bundled_products', 'edd_sanitize_bundled_products_save' );
+
+/**
+ * Sanitize bundled products conditions on save
+ *
+ * @since 3.1
+ *
+ * @param array $bundled_products_conditions
+ * @return array
+ */
+function edd_sanitize_bundled_products_conditions_save( $bundled_products_conditions = array() ) {
+	return array_combine(
+		range( 1, count( $bundled_products_conditions ) ),
+		array_values( $bundled_products_conditions )
+	);
+}
+add_filter( 'edd_metabox_save__edd_bundled_products_conditions', 'edd_sanitize_bundled_products_conditions_save' );
 
 /**
  * Don't save blank rows.

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -184,7 +184,7 @@ function edd_sanitize_bundled_products_save( $products = array() ) {
 add_filter( 'edd_metabox_save__edd_bundled_products', 'edd_sanitize_bundled_products_save' );
 
 /**
- * Sanitize bundled products conditions on save
+ * Sanitize bundled products conditions on save.
  *
  * @since 3.1
  *

--- a/tests/downloads/tests-downloads.php
+++ b/tests/downloads/tests-downloads.php
@@ -315,4 +315,17 @@ class Tests_Downloads extends EDD_UnitTestCase {
 		$this->assertTrue( edd_download_quantities_disabled( $this->_post->ID ) );
 	}
 
+	public function test_bundled_products_conditions_price_id_has_one_download() {
+		$bundle            = EDD_Helper_Download::create_variable_bundled_download();
+		$bundled_downloads = edd_get_bundled_products( $bundle->ID, 2 );
+
+		$this->assertEquals( 1, count( $bundled_downloads ) );
+	}
+
+	public function test_bundled_products_conditions_no_price_id_has_two_downloads() {
+		$bundle            = EDD_Helper_Download::create_variable_bundled_download();
+		$bundled_downloads = edd_get_bundled_products( $bundle->ID );
+
+		$this->assertEquals( 2, count( $bundled_downloads ) );
+	}
 }

--- a/tests/helpers/class-helper-download.php
+++ b/tests/helpers/class-helper-download.php
@@ -233,4 +233,57 @@ class EDD_Helper_Download extends WP_UnitTestCase {
 
 	}
 
+	public static function create_variable_bundled_download() {
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Variable Bundled Test Download Product',
+				'post_name'   => 'variable-bundled-test-download-product',
+				'post_type'   => 'download',
+				'post_status' => 'publish',
+			)
+		);
+
+		$simple_download   = self::create_simple_download();
+		$variable_download = self::create_variable_download();
+		$_variable_pricing = array(
+			array(
+				'name'   => 'Advanced',
+				'amount' => 100,
+			),
+			array(
+				'name'   => 'Enterprise',
+				'amount' => 200,
+			),
+			array(
+				'name'   => 'Corporate',
+				'amount' => 300,
+			),
+		);
+
+		$meta = array(
+			'edd_price'                        => 9.99,
+			'_variable_pricing'                => 1,
+			'edd_variable_prices'              => array_values( $_variable_pricing ),
+			'edd_download_files'               => array(),
+			'_edd_bundled_products'            => array(
+				1 => $simple_download->ID,
+				2 => $variable_download->ID,
+			),
+			'_edd_bundled_products_conditions' => array(
+				1 => 1,
+				2 => 2,
+			),
+			'_edd_download_limit'              => 20,
+			'edd_product_notes'                => 'Bundled Purchase Notes',
+			'_edd_product_type'                => 'bundle',
+			'_edd_download_earnings'           => 120,
+			'_edd_download_sales'              => 12,
+		);
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		return get_post( $post_id );
+	}
 }


### PR DESCRIPTION
Fixes #9343 

Proposed Changes:
1. Adds a metabox save sanitization so that we ensure that we also re-index the bundle file conditions array as well.