### PR TITLE
Get a large number of tax rates for the settings screen

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -2708,7 +2708,7 @@ function edd_recapture_callback($args) {
  * @return void
  */
 function edd_tax_rates_callback( $args ) {
-	$rates = edd_get_tax_rates( array(), OBJECT );
+	$rates = edd_get_tax_rates( array( 'number' => 9999 ), OBJECT );
 
 	wp_enqueue_script( 'edd-admin-tax-rates' );
 	wp_enqueue_style( 'edd-admin-tax-rates' );


### PR DESCRIPTION
Fixes #9432

Proposed Changes:
1. Sets the number of tax rates to retrieve for the settings callback to `9999`.