### PR TITLE
Update download sales/earning calculations

### DIFF
--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -930,7 +930,7 @@ class Stats {
 		$this->query_vars['table']             = $this->get_db()->edd_order_items;
 		$this->query_vars['column']            = true === $this->query_vars['exclude_taxes'] ? 'total - tax' : 'total';
 		$this->query_vars['date_query_column'] = 'date_created';
-		$this->query_vars['status']            = array( 'complete' );
+		$this->query_vars['status']            = array( 'complete', 'refunded', 'partially_refunded' );
 
 		// Run pre-query checks and maybe generate SQL.
 		$this->pre_query( $query );

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -1035,7 +1035,7 @@ class Stats {
 		$this->query_vars['table']             = $this->get_db()->edd_order_items;
 		$this->query_vars['column']            = 'id';
 		$this->query_vars['date_query_column'] = 'date_created';
-		$this->query_vars['status']            = array( 'complete' );
+		$this->query_vars['status']            = array( 'complete', 'refunded', 'partially_refunded' );
 
 		// Run pre-query checks and maybe generate SQL.
 		$this->pre_query( $query );

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -958,6 +958,7 @@ class Stats {
 		if ( ! empty( $country ) || ! empty( $region ) ) {
 			$join .= " INNER JOIN {$this->get_db()->edd_order_addresses} edd_oa ON {$this->query_vars['table']}.order_id = edd_oa.order_id ";
 		}
+
 		if ( ! empty( $this->query_vars['currency'] ) && array_key_exists( strtoupper( $this->query_vars['currency'] ), edd_get_currencies() ) ) {
 			$join     .= " INNER JOIN {$this->get_db()->edd_orders} edd_o ON ({$this->query_vars['table']}.order_id = edd_o.id) ";
 			$currency = $this->get_db()->prepare( "AND edd_o.currency = %s", strtoupper( $this->query_vars['currency'] ) );

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -1035,14 +1035,14 @@ class Stats {
 		$this->query_vars['table']             = $this->get_db()->edd_order_items;
 		$this->query_vars['column']            = 'id';
 		$this->query_vars['date_query_column'] = 'date_created';
-		$this->query_vars['status']            = array( 'complete', 'refunded', 'partially_refunded' );
+		$this->query_vars['status']            = array( 'complete', 'partially_refunded' );
 
 		// Run pre-query checks and maybe generate SQL.
 		$this->pre_query( $query );
 
 		$function = $this->get_amount_column_and_function( array(
 			'column_prefix'      => $this->query_vars['table'],
-			'accepted_functions' => array( 'COUNT', 'AVG' )
+			'accepted_functions' => array( 'COUNT', 'AVG' ),
 		) );
 
 		$product_id = ! empty( $this->query_vars['product_id'] )
@@ -1059,12 +1059,12 @@ class Stats {
 			? $this->get_db()->prepare( 'AND edd_oa.country = %s', esc_sql( $this->query_vars['country'] ) )
 			: '';
 
-		$join = $currency = '';
+		$join     = "INNER JOIN {$this->get_db()->edd_orders} edd_o ON ({$this->query_vars['table']}.order_id = edd_o.id) AND edd_o.status IN('complete','partially_refunded') AND edd_o.type = 'sale' ";
+		$currency = '';
 		if ( ! empty( $country ) || ! empty( $region ) ) {
 			$join .= " INNER JOIN {$this->get_db()->edd_order_addresses} edd_oa ON {$this->query_vars['table']}.order_id = edd_oa.order_id ";
 		}
 		if ( ! empty( $this->query_vars['currency'] ) && array_key_exists( strtoupper( $this->query_vars['currency'] ), edd_get_currencies() ) ) {
-			$join     .= " INNER JOIN {$this->get_db()->edd_orders} edd_o ON ({$this->query_vars['table']}.order_id = edd_o.id) ";
 			$currency = $this->get_db()->prepare( "AND edd_o.currency = %s", strtoupper( $this->query_vars['currency'] ) );
 		}
 
@@ -1107,7 +1107,7 @@ class Stats {
 			} );
 		} else {
 			$result = null === $result[0]->total
-				? 0.00
+				? 0
 				: absint( $result[0]->total );
 		}
 

--- a/includes/models/Download.php
+++ b/includes/models/Download.php
@@ -136,7 +136,7 @@ class Download {
 			INNER JOIN {$wpdb->edd_orders} o ON(o.id = oi.order_id)
 			WHERE {$product_id_sql}
 			{$price_id_sql}
-			AND oi.status IN('complete','partially_refunded')
+			AND oi.status IN('complete','refunded','partially_refunded')
 			{$order_status_sql} {$date_query_sql}";
 		$partial_orders  =
 			"SELECT SUM(oi.quantity) as sales
@@ -165,7 +165,7 @@ class Download {
 
 		$product_id_sql   = $this->generate_product_id_query_sql();
 		$price_id_sql     = $this->generate_price_id_query_sql();
-		$order_status_sql = $this->generate_order_status_query_sql();
+		$order_status_sql = $this->generate_order_status_query_sql( false );
 		$date_query_sql   = $this->generate_date_query_sql();
 
 		/**
@@ -181,7 +181,7 @@ class Download {
 			INNER JOIN {$wpdb->edd_orders} o ON(o.id = oi.order_id)
 			WHERE {$product_id_sql}
 			{$price_id_sql}
-			AND oi.status IN('complete','partially_refunded')
+			AND oi.status IN('complete','partially_refunded','refunded')
 			{$order_status_sql} {$date_query_sql}";
 		$order_adjustments =
 			"SELECT SUM((oa.total - oa.tax)/ oa.rate) as revenue

--- a/tests/orders/tests-stats.php
+++ b/tests/orders/tests-stats.php
@@ -193,20 +193,20 @@ class Stats_Tests extends \EDD_UnitTestCase {
 	/**
 	 * @covers ::get_order_item_count
 	 */
-	public function test_get_order_item_count_no_price_id_should_be_2() {
+	public function test_get_order_item_count_no_price_id_should_be_3() {
 		$count = self::$stats->get_order_item_count(
 			array(
 				'product_id' => 1,
 			)
 		);
 
-		$this->assertSame( 2, $count );
+		$this->assertSame( 3, $count );
 	}
 
 	/**
 	 * @covers ::get_order_item_count
 	 */
-	public function test_get_order_item_count_null_price_id_should_be_2() {
+	public function test_get_order_item_count_null_price_id_should_be_3() {
 		$count = self::$stats->get_order_item_count(
 			array(
 				'product_id' => 1,
@@ -214,7 +214,7 @@ class Stats_Tests extends \EDD_UnitTestCase {
 			)
 		);
 
-		$this->assertSame( 2, $count );
+		$this->assertSame( 3, $count );
 	}
 
 	/**

--- a/tests/phpunit/factories/class-edd-factory-for-orders.php
+++ b/tests/phpunit/factories/class-edd-factory-for-orders.php
@@ -40,12 +40,13 @@ class Order extends \WP_UnitTest_Factory_For_Thing {
 
 	public function create_object( $args ) {
 		$order_id = edd_add_order( $args );
+		$order    = edd_get_order( $order_id );
 
 		$oid = edd_add_order_item( array(
 			'order_id'     => $order_id,
 			'product_id'   => 1,
 			'product_name' => 'Simple Download',
-			'status'       => 'inherit',
+			'status'       => $order->status,
 			'amount'       => 100,
 			'subtotal'     => 100,
 			'discount'     => 5,


### PR DESCRIPTION
Fixes #9424

Proposed Changes:
1. Updates the net sales/earnings calculations method in the download model to query order items that are complete, refunded, and partially refunded, and to use gross order statuses for calculating earnings.
2. Updates the stats class for querying order items to always do an inner join to the orders table, because we need to know what type and status the order has. So the count now gets complete/partially refunded counts for orders of the type sale which are also complete/partially refunded. _Reminder that the stats count is counting rows and the download model is doing quantities._
3. Fixes the order factory for unit tests to set a correct order item status.
4. Updates the stats tests to expect the correct number of order items.