### PR TITLE
Update download name when adding as a payment

### DIFF
--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -617,7 +617,7 @@ class EDD_CLI extends WP_CLI_Command {
 				);
 
 				$cart_details[ $key ] = array(
-					'name'        => $download->post_title,
+					'name'        => edd_get_download_name( $download->ID, $price_id ),
 					'id'          => $download->ID,
 					'item_number' => $item_number,
 					'item_price'  => edd_sanitize_amount( $item_price ),

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -1109,7 +1109,7 @@ class EDD_Payment {
 		);
 
 		$this->cart_details[] = array(
-			'name'        => $download->post_title,
+			'name'        => edd_get_download_name( $download->ID, $args['price_id'] ),
 			'id'          => $download->ID,
 			'item_number' => $item_number,
 			'item_price'  => round( $item_price, edd_currency_decimal_filter() ),


### PR DESCRIPTION
Fixes #9157

Proposed Changes:
1. Updates the payment class and the CLI functionality to use `edd_get_download_name()` to record the product name.