### PR TITLE
Responsive fixes for email summary

### DIFF
--- a/includes/emails/email-summary/edd-email-summary-template.php
+++ b/includes/emails/email-summary/edd-email-summary-template.php
@@ -7,154 +7,157 @@
 			<!--[if !mso]><!-->
 			<meta http-equiv="X-UA-Compatible" content="IE=edge">
 			<!--<![endif]-->
-		</head>
-		<style>
-			@media only screen and (max-width: 480px) {
-				body {
-					max-width: 320px;
-				}
 
-				.push-down-25 {
-					margin-bottom: 20px;
-				}
-				.pull-down-8 {
-					margin-top: 4px !important;
-				}
-				.pull-down-5 {
-					margin-top: 2.5px !important;
-				}
-				h1 {
-					font-size: 18px !important;
-					line-height: 24px !important;
-				}
-				h2 {
-					font-size: 12px !important;
-					line-height: 16px !important;
-				}
-				p {
-					font-size: 10px !important;
-					line-height: 13px !important;
-				}
-				p.bigger {
-					font-size: 10px !important;
-					line-height: 16px !important;
-				}
-				.email-header-holder {
-					max-height: 50px !important;
-					height: 50px !important;
-				}
-				.logo-holder {
-					padding: 10px 22px 5px 22px !important;
-				}
-				.logo-holder .edd-logo {
-					max-width: 175px !important;
-					max-height: 28px !important;
-				}
-				.content-holder {
-					padding: 22px 22px 0px 22px !important;
-				}
-				.content-holder.pro-tip-section {
-					padding: 0px 22px 27px 22px !important;
-				}
-				.period-date {
-					font-size: 10px !important;
-					line-height: 13px !important;
-				}
-				.link-style {
-					font-size: 10px !important;
-					line-height: 13px !important;
-				}
-				.link-style.bigger {
-					font-size: 10px !important;
-					line-height: 13px !important;
-				}
-				.stats-totals-wrapper {
-					margin-top: 38px !important;
-				}
-				.stats-totals-wrapper td {
-					font-size: 12px !important;
-					border-collapse: collapse !important;
-				}
-				.stats-total-item {
-					width: 145px;
-					display: inline-table;
-					min-width: 145px;
-				}
-				.stats-total-item-inner {
-					font-size: 12px !important;
-					border-collapse: collapse !important;
-				}
-				.stats-total-item-title {
-					font-size: 12px !important;
-					line-height: 15px !important;
-					margin-bottom: 2.5px !important;
-				}
-				.stats-total-item-value {
-					line-height: 18px !important;
-					font-size: 16px !important;
-				}
-				.stats-total-item-percent {
-					line-height: 8px !important;
-					font-size: 8px !important;
-					white-space: nowrap;
-				}
-				.stats-total-item-percent span.comparison {
-					font-style: normal;
-					font-weight: lighter;
-					font-size: 8px !important;
-					line-height: 10px !important;
-					margin-top: 3px !important;
-				}
-				.stats-total-item-percent img {
-					width: 8px !important;
-					height: 6px !important;
-					vertical-align: baseline !important;
-				}
-				.table-top-title {
-					font-size: 12px !important;
-					line-height: 15px !important;
-				}
-				table.top-products tr th {
-					padding: 6px 0px !important;
-					font-size: 10px !important;
-					line-height: 13px !important;
-				}
-				table.top-products tr td {
-					font-size: 10px !important;
-					padding: 6px 0px !important;
-					border-bottom: 1px solid #F0F1F4;
-				}
-				table.top-products tr td:nth-child(2) {
-					font-size: 12px !important;
-				}
-				.pro-tip-holder {
-					background: #F3F8FE;
-					border-radius: 8px !important;
-					padding: 24px 24px !important;
-				}
-				.pro-tip-section-title {
-					font-size: 14px !important;
-					line-height: 15px !important;
-				}
-				.pro-tip-section-title img {
-					margin-right: 3px !important;
-				}
-				.pro-tip-title {
-					font-size: 12px !important;
-					line-height: 16px !important;
-				}
-				.cta-btn {
-					padding: 6px 15px;
-					font-weight: 600;
-					font-size: 14px;
-					line-height: 20px;
-					background: #2794DA;
-					display: inline-block;
-					color: #FFFFFF;
-					text-decoration: none;
-				}
+			<style>
+				@media only screen and (max-width: 480px) {
+					body {
+						max-width: 320px;
+					}
+					.push-down-25 {
+						margin-bottom: 25px;
+					}
+					.pull-down-8 {
+						margin-top: 8px !important;
+					}
+					.pull-down-5 {
+						margin-top: 5px !important;
+					}
+					h1 {
+						font-size: 20px !important;
+						line-height: 26px !important;
+					}
+					h2 {
+						font-size: 16px !important;
+						line-height: 22px !important;
+					}
+					p {
+						font-size: 12px !important;
+						line-height: 17px !important;
+					}
+					p.bigger {
+						font-size: 12px !important;
+						line-height: 16px !important;
+					}
+					.email-header-holder {
+						max-height: 50px !important;
+						height: 50px !important;
+					}
+					.logo-holder {
+						padding: 10px 22px 5px 22px !important;
+					}
+					.logo-holder .edd-logo {
+						max-width: 175px !important;
+						max-height: 28px !important;
+					}
+					.content-holder {
+						padding: 22px 22px 0px 22px !important;
+					}
+					.content-holder.pro-tip-section {
+						padding: 0px 22px 27px 22px !important;
+					}
+					.period-date {
+						font-size: 12px !important;
+						line-height: 15px !important;
+					}
+					.link-style {
+						font-size: 12px !important;
+						line-height: 15px !important;
+					}
+					.link-style.bigger {
+						font-size: 12px !important;
+						line-height: 15px !important;
+					}
+					.stats-totals-wrapper {
+						margin-top: 38px !important;
+					}
+					.stats-totals-wrapper td {
+						font-size: 12px !important;
+						border-collapse: collapse !important;
+					}
+					.stats-total-item {
+						width: 145px;
+						display: inline-table;
+						min-width: 145px;
+					}
+					.stats-total-item-inner {
+						font-size: 12px !important;
+						border-collapse: collapse !important;
+					}
+					.stats-total-item-title {
+						font-size: 16px !important;
+						line-height: 19px !important;
+						margin-bottom: 10px !important;
+					}
+					.stats-total-item-value {
+						line-height: 18px !important;
+						font-size: 16px !important;
+						margin: 0 0 11px 0px !important;
+					}
+					.stats-total-item-percent {
+						line-height: 11px !important;
+						font-size: 11px !important;
+						white-space: nowrap;
+					}
+					.stats-total-item-percent span.comparison {
+						font-style: normal;
+						font-weight: lighter;
+						font-size: 11px !important;
+						line-height: 15px !important;
+						margin-top: 5px !important;
+					}
+					.stats-total-item-percent img {
+						width: 8px !important;
+						height: 6px !important;
+						vertical-align: baseline !important;
+					}
+					.table-top-title {
+						font-size: 12px !important;
+						line-height: 15px !important;
+					}
+					table.top-products tr th {
+						padding: 8px 0px !important;
+						font-size: 12px !important;
+						line-height: 15px !important;
+					}
+					table.top-products tr td {
+						font-size: 12px !important;
+						padding: 10px 0px !important;
+						border-bottom: 1px solid #F0F1F4;
+					}
+					table.top-products tr td:nth-child(2) {
+						font-size: 12px !important;
+					}
+					.pro-tip-holder {
+						background: #F3F8FE;
+						border-radius: 8px !important;
+						padding: 24px 24px !important;
+					}
+					.pro-tip-section-title {
+						font-size: 14px !important;
+						line-height: 15px !important;
+					}
+					.pro-tip-section-title img {
+						margin-right: 3px !important;
+					}
+					.pro-tip-title {
+						font-size: 14px !important;
+						line-height: 18px !important;
+					}
+					.cta-btn {
+						padding: 6px 15px;
+						font-weight: 600;
+						font-size: 16px;
+						line-height: 20px;
+						background: #2794DA;
+						display: inline-block;
+						color: #FFFFFF;
+						text-decoration: none;
+					}
 			}
-		</style>
+			</style>
+
+		</head>
+
 
 		<body style="margin: 0px auto; max-width: 450px;">
 			<!-- PREVIEW TEXT -->


### PR DESCRIPTION
Responsive improvements for Email Summaries.
Made mobile fonts bigger and put `<style>` into `<head>` so that email clients are not stripping the CSS out of email.