### PR TITLE
Cleanup product education and remove old promo strings

### DIFF
--- a/includes/admin/add-ons.php
+++ b/includes/admin/add-ons.php
@@ -104,32 +104,6 @@ function edd_add_ons_page() {
 
 		<div class="edd-add-ons-container">
 			<?php
-
-			// Display a promotional element before all add ons if a promotion is active.
-			$is_promo_active = edd_is_promo_active();
-			if ( true === $is_promo_active ) {
-
-				// Build the main URL for the promotion.
-				$args = array(
-					'utm_source'   => 'add-ons-feed',
-					'utm_medium'   => 'wp-admin',
-					'utm_campaign' => 'bfcm2019',
-					'utm_content'  => 'first-feed-element-' . sanitize_key( $active_tab ),
-				);
-				$url  = add_query_arg( $args, 'https://easydigitaldownloads.com/pricing/' );
-				?>
-				<div class="edd-add-ons-promo edd-extension">
-					<h3 class="edd-extension-title">Black Friday & Cyber Monday sale!</h3>
-					<a href="<?php echo esc_url( $url ); ?>" title="Black Friday & Cyber Monday sale">
-						<img class="attachment-download-grid-thumb size-download-grid-thumb wp-post-image" src="<?php echo esc_url( EDD_PLUGIN_URL . 'assets/images/promo/edd-25-percent-off.png' ); ?>">
-					</a>
-					<p><?php echo wp_kses_post( __( 'Save 25% on all Easy Digital Downloads purchases <strong>this week</strong>, including renewals and upgrades! Use code <span class="bfcm-code">BFCM2019</span> at checkout.', 'easy-digital-downloads' ) ); ?></p>
-					<a class="button-secondary" href="<?php echo esc_url( $url ); ?>" target="_blank"><?php esc_html_e( 'Don\'t miss out!', 'easy-digital-downloads' ); ?></a>
-					<span class="sale-ends"><?php esc_html_e( 'Sale ends 23:59 PM December 6th CST', 'easy-digital-downloads' ); ?></span>
-				</div>
-				<?php
-			}
-
 			// Display all add ons.
 			echo wp_kses_post( edd_add_ons_get_feed( $active_tab ) );
 			?>

--- a/includes/admin/admin-bar.php
+++ b/includes/admin/admin-bar.php
@@ -132,7 +132,7 @@ function edd_maybe_add_store_mode_admin_bar_menu( $wp_admin_bar ) {
 			'parent' => 'edd-store-menu',
 			'id'     => 'edd-upgrade',
 			'title'  => esc_html__( 'Upgrade to Pro', 'easy-digital-downloads' ),
-			'href'   => 'https://easydigitaldownloads.com/pricing/?utm_campaign=admin&utm_medium=admin-bar&utm_source=WordPress&utm_content=Upgrade+to+Pro',
+			'href'   => 'https://easydigitaldownloads.com/lite-upgrade/?utm_campaign=admin&utm_medium=admin-bar&utm_source=WordPress&utm_content=Upgrade+to+Pro',
 			'meta'   => array(
 				'target' => '_blank',
 				'rel'    => 'noopener noreferrer',

--- a/includes/admin/discounts/contextual-help.php
+++ b/includes/admin/discounts/contextual-help.php
@@ -27,7 +27,7 @@ function edd_discounts_contextual_help() {
 	if ( $pass_manager->isFree() ) {
 		$screen->set_help_sidebar(
 			'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
+			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://easydigitaldownloads.com/docs/' ) ) . '</p>' .
 			'<p>' . sprintf(
 				__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
 				esc_url( 'https://easydigitaldownloads.com/lite-upgrade/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )

--- a/includes/admin/discounts/contextual-help.php
+++ b/includes/admin/discounts/contextual-help.php
@@ -9,6 +9,8 @@
  * @since       1.2.3
  */
 
+use EDD\Admin\Pass_Manager;
+
 // Exit if accessed directly
 defined( 'ABSPATH' ) || exit;
 
@@ -21,14 +23,17 @@ defined( 'ABSPATH' ) || exit;
 function edd_discounts_contextual_help() {
 	$screen = get_current_screen();
 
-	$screen->set_help_sidebar(
-		'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
-		'<p>' . sprintf(
-			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
-			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
-		) . '</p>'
-	);
+	$pass_manager = new Pass_Manager();
+	if ( $pass_manager->isFree() ) {
+		$screen->set_help_sidebar(
+			'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
+			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
+			'<p>' . sprintf(
+				__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
+				esc_url( 'https://easydigitaldownloads.com/lite-upgrade/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
+			) . '</p>'
+		);
+	}
 
 	$screen->add_help_tab( array(
 		'id'	    => 'edd-discount-general',

--- a/includes/admin/downloads/contextual-help.php
+++ b/includes/admin/downloads/contextual-help.php
@@ -31,7 +31,7 @@ function edd_downloads_contextual_help() {
 	if ( $pass_manager->isFree() ) {
 		$screen->set_help_sidebar(
 			'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
+			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://easydigitaldownloads.com/docs/' ) ) . '</p>' .
 			'<p>' . sprintf(
 				__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
 				esc_url( 'https://easydigitaldownloads.com/lite-upgrade/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )

--- a/includes/admin/downloads/contextual-help.php
+++ b/includes/admin/downloads/contextual-help.php
@@ -9,6 +9,8 @@
  * @since       1.2.3
  */
 
+use EDD\Admin\Pass_Manager;
+
 // Exit if accessed directly
 defined( 'ABSPATH' ) || exit;
 
@@ -21,17 +23,21 @@ defined( 'ABSPATH' ) || exit;
 function edd_downloads_contextual_help() {
 	$screen = get_current_screen();
 
-	if ( $screen->id != 'download' )
+	if ( $screen->id != 'download' ) {
 		return;
+	}
 
-	$screen->set_help_sidebar(
-		'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
-		'<p>' . sprintf(
-			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
-			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
-		) . '</p>'
-	);
+	$pass_manager = new Pass_Manager();
+	if ( $pass_manager->isFree() ) {
+		$screen->set_help_sidebar(
+			'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
+			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
+			'<p>' . sprintf(
+				__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
+				esc_url( 'https://easydigitaldownloads.com/lite-upgrade/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
+			) . '</p>'
+		);
+	}
 
 	$screen->add_help_tab( array(
 		'id'	    => 'edd-download-configuration',

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -1305,34 +1305,3 @@ function edd_render_stats_meta_box() {
 <?php
 	do_action('edd_stats_meta_box');
 }
-
-/**
- * Outputs a metabox for promotional content.
- *
- * @since 2.9.20
- * @return void
- */
-function edd_render_promo_metabox() {
-	ob_start();
-
-	// Build the main URL for the promotion.
-	$args = array(
-		'utm_source'   => 'download-metabox',
-		'utm_medium'   => 'wp-admin',
-		'utm_campaign' => 'bfcm2019',
-		'utm_content'  => 'bfcm-metabox',
-	);
-	$url  = add_query_arg( $args, 'https://easydigitaldownloads.com/pricing/' );
-	?>
-	<p>
-		<?php
-		// Translators: The %s represents the link to the pricing page on the Easy Digital Downloads website.
-		echo wp_kses_post( sprintf( __( 'Save 25&#37; on all Easy Digital Downloads purchases <strong>this week</strong>, including renewals and upgrades! Sale ends 23:59 PM December 6th CST. <a target="_blank" href="%s">Don\'t miss out</a>!', 'easy-digital-downloads' ), esc_url( $url ) ) );
-		?>
-	</p>
-	<?php
-	$rendered = ob_get_contents();
-	ob_end_clean();
-
-	echo wp_kses_post( $rendered );
-}

--- a/includes/admin/extensions/abstract-extension.php
+++ b/includes/admin/extensions/abstract-extension.php
@@ -275,7 +275,7 @@ abstract class Extension {
 	 * @return string
 	 */
 	private function get_upgrade_url( ProductData $product_data, $item_id, $has_access = false ) {
-		$url            = 'https://easydigitaldownloads.com/pricing';
+		$url            = 'https://easydigitaldownloads.com/lite-upgrade';
 		$utm_parameters = array(
 			'p'            => urlencode( $item_id ),
 			'utm_source'   => 'settings',

--- a/includes/admin/payments/contextual-help.php
+++ b/includes/admin/payments/contextual-help.php
@@ -9,6 +9,8 @@
  * @since       1.4
  */
 
+use EDD\Admin\Pass_Manager;
+
 // Exit if accessed directly
 defined( 'ABSPATH' ) || exit;
 
@@ -32,14 +34,17 @@ function edd_payments_contextual_help() {
 		return;
 	}
 
-	$screen->set_help_sidebar(
-		'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
-		'<p>' . sprintf(
-			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
-			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
-		) . '</p>'
-	);
+	$pass_manager = new Pass_Manager();
+	if ( $pass_manager->isFree() ) {
+		$screen->set_help_sidebar(
+			'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
+			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
+			'<p>' . sprintf(
+				__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
+				esc_url( 'https://easydigitaldownloads.com/lite-upgrade/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
+			) . '</p>'
+		);
+	}
 
 	$screen->add_help_tab( array(
 		'id'	    => 'edd-payments-overview',

--- a/includes/admin/payments/contextual-help.php
+++ b/includes/admin/payments/contextual-help.php
@@ -38,7 +38,7 @@ function edd_payments_contextual_help() {
 	if ( $pass_manager->isFree() ) {
 		$screen->set_help_sidebar(
 			'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
+			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://easydigitaldownloads.com/docs/' ) ) . '</p>' .
 			'<p>' . sprintf(
 				__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
 				esc_url( 'https://easydigitaldownloads.com/lite-upgrade/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )

--- a/includes/admin/promos/notices/class-license-upgrade-notice.php
+++ b/includes/admin/promos/notices/class-license-upgrade-notice.php
@@ -166,7 +166,7 @@ class License_Upgrade_Notice extends Notice {
 				printf(
 				/* Translators: %1$s opening anchor tag; %2$s closing anchor tag */
 					__( 'You are using the free version of Easy Digital Downloads. %1$sPurchase a pass%2$s to get email marketing tools and recurring payments. %3$sAlready have a Pass?%4$s', 'easy-digital-downloads' ),
-					'<a href="' . esc_url( add_query_arg( $this->query_args( 'core', urlencode( $source ) ), 'https://easydigitaldownloads.com/pricing/' ) ) . '" target="_blank">',
+					'<a href="' . esc_url( add_query_arg( $this->query_args( 'core', urlencode( $source ) ), 'https://easydigitaldownloads.com/lite-upgrade/' ) ) . '" target="_blank">',
 					'</a>',
 					'<a href="' . esc_url( add_query_arg( $this->query_args( 'core', urlencode( $source ) ), 'https://easydigitaldownloads.com/what-is-an-edd-pass' ) ) . '" target="_blank">',
 					'</a>'
@@ -178,7 +178,7 @@ class License_Upgrade_Notice extends Notice {
 				printf(
 				/* Translators: %1$s opening anchor tag; %2$s closing anchor tag */
 					__( 'For access to additional Easy Digital Downloads extensions to grow your store, consider %1$spurchasing a pass%2$s.', 'easy-digital-downloads' ),
-					'<a href="' . esc_url( add_query_arg( $this->query_args( 'extension-license', urlencode( $source ) ), 'https://easydigitaldownloads.com/pricing/' ) ) . '" target="_blank">',
+					'<a href="' . esc_url( add_query_arg( $this->query_args( 'extension-license', urlencode( $source ) ), 'https://easydigitaldownloads.com/lite-upgrade/' ) ) . '" target="_blank">',
 					'</a>'
 				);
 

--- a/includes/admin/reporting/contextual-help.php
+++ b/includes/admin/reporting/contextual-help.php
@@ -9,6 +9,8 @@
  * @since       1.4
  */
 
+use EDD\Admin\Pass_Manager;
+
 // Exit if accessed directly
 defined( 'ABSPATH' ) || exit;
 
@@ -22,17 +24,21 @@ defined( 'ABSPATH' ) || exit;
 function edd_reporting_contextual_help() {
 	$screen = get_current_screen();
 
-	if ( $screen->id != 'download_page_edd-reports' )
+	if ( $screen->id != 'download_page_edd-reports' ) {
 		return;
+	}
 
-	$screen->set_help_sidebar(
-		'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
-		'<p>' . sprintf(
-			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
-			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
-		) . '</p>'
-	);
+	$pass_manager = new Pass_Manager();
+	if ( $pass_manager->isFree() ) {
+		$screen->set_help_sidebar(
+			'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
+			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
+			'<p>' . sprintf(
+				__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
+				esc_url( 'https://easydigitaldownloads.com/lite-upgrade/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
+			) . '</p>'
+		);
+	}
 
 	$screen->add_help_tab( array(
 		'id'	    => 'edd-reports',

--- a/includes/admin/reporting/contextual-help.php
+++ b/includes/admin/reporting/contextual-help.php
@@ -32,7 +32,7 @@ function edd_reporting_contextual_help() {
 	if ( $pass_manager->isFree() ) {
 		$screen->set_help_sidebar(
 			'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
+			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://easydigitaldownloads.com/docs/' ) ) . '</p>' .
 			'<p>' . sprintf(
 				__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now</a>!', 'easy-digital-downloads' ),
 				esc_url( 'https://easydigitaldownloads.com/lite-upgrade/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )

--- a/includes/admin/settings/contextual-help.php
+++ b/includes/admin/settings/contextual-help.php
@@ -32,7 +32,7 @@ function edd_settings_contextual_help() {
 	if ( $pass_manager->isFree() ) {
 		$screen->set_help_sidebar(
 			'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
+			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://easydigitaldownloads.com/docs/' ) ) . '</p>' .
 			'<p>' . sprintf(
 				__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now!</a>.', 'easy-digital-downloads' ),
 				esc_url( 'https://easydigitaldownloads.com/lite-upgrade/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )

--- a/includes/admin/settings/contextual-help.php
+++ b/includes/admin/settings/contextual-help.php
@@ -9,6 +9,8 @@
  * @since       1.4
  */
 
+use EDD\Admin\Pass_Manager;
+
 // Exit if accessed directly
 defined( 'ABSPATH' ) || exit;
 
@@ -26,14 +28,17 @@ function edd_settings_contextual_help() {
 		return;
 	}
 
-	$screen->set_help_sidebar(
-		'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
-		'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
-		'<p>' . sprintf(
-			__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now!</a>.', 'easy-digital-downloads' ),
-			esc_url( 'https://easydigitaldownloads.com/pricing/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
-		) . '</p>'
-	);
+	$pass_manager = new Pass_Manager();
+	if ( $pass_manager->isFree() ) {
+		$screen->set_help_sidebar(
+			'<p><strong>' . __( 'For more information:', 'easy-digital-downloads' ) . '</strong></p>' .
+			'<p>' . sprintf( __( 'Visit the <a href="%s">documentation</a> on the Easy Digital Downloads website.', 'easy-digital-downloads' ), esc_url( 'https://docs.easydigitaldownloads.com/' ) ) . '</p>' .
+			'<p>' . sprintf(
+				__( 'Need more from your Easy Digital Downloads store? <a href="%s">Upgrade Now!</a>.', 'easy-digital-downloads' ),
+				esc_url( 'https://easydigitaldownloads.com/lite-upgrade/?utm_source=plugin-settings-page&utm_medium=contextual-help-sidebar&utm_term=pricing&utm_campaign=ContextualHelp' )
+			) . '</p>'
+		);
+	}
 
 	$screen->add_help_tab( array(
 		'id'      => 'edd-settings-general',

--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -248,15 +248,9 @@ function edd_options_page_form( $active_tab = '', $section = '', $override = fal
 	$suffix = ! empty( $section )
 		? $active_tab . '_' . $section
 		: $active_tab . '_main';
-
-	// Find out if we're displaying a sidebar.
-	$is_promo_active = edd_is_promo_active();
-	$wrapper_class   = ( true === $is_promo_active )
-		? array( ' edd-has-sidebar' )
-		: array();
 	?>
 
-	<div class="edd-settings-wrap<?php echo esc_attr( implode( ' ', $wrapper_class ) ); ?> wp-clearfix">
+	<div class="edd-settings-wrap wp-clearfix">
 		<div class="edd-settings-content">
 			<form method="post" action="options.php" class="edd-settings-form">
 				<?php
@@ -287,60 +281,8 @@ function edd_options_page_form( $active_tab = '', $section = '', $override = fal
 				submit_button(); ?>
 			</form>
 		</div>
-		<?php
-		if ( true === $is_promo_active ) {
-			edd_options_sidebar();
-		}
-		?>
 	</div>
 
-	<?php
-}
-
-/**
- * Display the sidebar
- *
- * @since 2.9.20
- *
- * @return string
- */
-function edd_options_sidebar() {
-	// Get settings tab and section info
-	$active_tab     = isset( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : 'general';
-	$active_tab     = array_key_exists( $active_tab, edd_get_settings_tabs() ) ? $active_tab : 'general';
-	$active_section = isset( $_GET['section'] ) ? sanitize_text_field( $_GET['section'] ) : 'main';
-	$active_section = array_key_exists( $active_section, edd_get_settings_tab_sections( $active_tab ) ) ? $active_section : 'main';
-
-	// The coupon code we're promoting
-	$coupon_code = 'BFCM2019';
-
-	// Build the main URL for the promotion
-	$args = array(
-		'utm_source'   => 'settings',
-		'utm_medium'   => 'wp-admin',
-		'utm_campaign' => 'bfcm2019',
-		'utm_content'  => sanitize_key( 'sidebar-promo-' . $active_tab . '-' . $active_section ),
-	);
-	$url  = add_query_arg( $args, 'https://easydigitaldownloads.com/pricing/' );
-	?>
-	<div class="edd-settings-sidebar">
-		<div class="edd-settings-sidebar-content">
-			<div class="edd-sidebar-header-section">
-				<img class="edd-bfcm-header" src="<?php echo esc_url( EDD_PLUGIN_URL . 'assets/images/promo/bfcm-header.svg' ); ?>">
-			</div>
-			<div class="edd-sidebar-description-section">
-				<p class="edd-sidebar-description"><?php _e( 'Save 25% on all Easy Digital Downloads purchases <strong>this week</strong>, including renewals and upgrades!', 'easy-digital-downloads' ); ?></p>
-			</div>
-			<div class="edd-sidebar-coupon-section">
-				<label for="edd-coupon-code"><?php _e( 'Use code at checkout:', 'easy-digital-downloads' ); ?></label>
-				<input id="edd-coupon-code" type="text" value="<?php echo esc_attr( $coupon_code ); ?>" readonly>
-				<p class="edd-coupon-note"><?php _e( 'Sale ends 23:59 PM December 6th CST. Save 25% on <a href="https://sandhillsdev.com/projects/" target="_blank">our other plugins</a>.', 'easy-digital-downloads' ); ?></p>
-			</div>
-			<div class="edd-sidebar-footer-section">
-				<a class="edd-cta-button" href="<?php echo esc_url( $url ); ?>" target="_blank"><?php _e( 'Shop Now!', 'easy-digital-downloads' ); ?></a>
-			</div>
-		</div>
-	</div>
 	<?php
 }
 

--- a/includes/deprecated-functions.php
+++ b/includes/deprecated-functions.php
@@ -1742,7 +1742,6 @@ function edd_render_review_status_metabox() {
 	_edd_deprecated_function( __FUNCTION__, '2.11.4' );
 
 	$reviews_location = edd_reviews_location();
-	$is_promo_active  = edd_is_promo_active();
 
 	ob_start();
 
@@ -1759,21 +1758,11 @@ function edd_render_review_status_metabox() {
 
 	} else {
 
-		// Adjust UTM params based on state of promotion.
-		if ( true === $is_promo_active ) {
-			$args = array(
-				'utm_source'   => 'download-metabox',
-				'utm_medium'   => 'wp-admin',
-				'utm_campaign' => 'bfcm2019',
-				'utm_content'  => 'product-reviews-metabox-bfcm',
-			);
-		} else {
-			$args = array(
-				'utm_source'   => 'edit-download',
-				'utm_medium'   => 'enable-reviews',
-				'utm_campaign' => 'admin',
-			);
-		}
+		$args = array(
+			'utm_source'   => 'edit-download',
+			'utm_medium'   => 'enable-reviews',
+			'utm_campaign' => 'admin',
+		);
 
 		$base_url = 'https://easydigitaldownloads.com/downloads/product-reviews';
 		$url      = add_query_arg( $args, $base_url );
@@ -1785,14 +1774,6 @@ function edd_render_review_status_metabox() {
 			?>
 		</p>
 		<?php
-		// Add an additional note if a promotion is active.
-		if ( true === $is_promo_active ) {
-			?>
-			<p>
-				<?php echo wp_kses_post( __( 'Act now and <strong>SAVE 25%</strong> on your purchase. Sale ends <em>23:59 PM December 6th CST</em>. Use code <code>BFCM2019</code> at checkout.', 'easy-digital-downloads' ) ); ?>
-			</p>
-			<?php
-		}
 	}
 
 	$rendered = ob_get_contents();
@@ -1910,4 +1891,34 @@ function edd_decrease_earnings( $download_id = 0, $amount = 0.00 ) {
 	}
 
 	return $download->get_earnings();
+}
+
+/**
+ * Check to see if we should be displaying promotional content
+ *
+ * In various parts of the plugin, we may choose to promote something like a sale for a limited time only. This
+ * function should be used to set the conditions under which the promotions will display.
+ *
+ * @since 2.9.20
+ * @deprecated 3.1
+ *
+ * @return bool
+ */
+function edd_is_promo_active() {
+	_edd_deprecated_function( __FUNCTION__, '3.1' );
+
+	return false;
+}
+
+/**
+ * Outputs a metabox for promotional content.
+ *
+ * @since 2.9.20
+ * @deprecated 3.1
+ *
+ * @return void
+ */
+function edd_render_promo_metabox() {
+	_edd_deprecated_function( __FUNCTION__, '3.1' );
+	return;
 }

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1741,31 +1741,6 @@ function edd_print_payment_icons( $icons = array() ) {
 }
 
 /**
- * Check to see if we should be displaying promotional content
- *
- * In various parts of the plugin, we may choose to promote something like a sale for a limited time only. This
- * function should be used to set the conditions under which the promotions will display.
- *
- * @since 2.9.20
- *
- * @return bool
- */
-function edd_is_promo_active() {
-
-	// Set the date/time range based on UTC.
-	$start = strtotime( '2019-11-29 06:00:00' );
-	$end   = strtotime( '2019-12-07 05:59:59' );
-	$now   = time();
-
-	// Only display sidebar if the page is loaded within the date range.
-	if ( ( $now > $start ) && ( $now < $end ) ) {
-		return true;
-	}
-
-	return false;
-}
-
-/**
  * Gets the date that this EDD install was activated (for new installs).
  * For existing installs, this option is added whenever the function is first used.
  *

--- a/readme.txt
+++ b/readme.txt
@@ -116,7 +116,7 @@ The Easy Digital Downloads API makes it possible for developers to make customiz
 
 = Get help =
 
-Easy Digital Downloads is backed by top-notch technical support from our globally distributed full-time support team. We also have an [extensive documentation site available](https://easydigitaldownloads.com/docs/?utm_medium=readme&utm_source=wporg&utm_campaign=lite-plugin&utm_content=docs&utm_term=description). If you're looking for faster support via email, we encourage you to [purchase an Easy Digital Downloads pass](https://easydigitaldownloads.com/pricing/?utm_medium=readme&utm_source=wporg&utm_campaign=lite-plugin&utm_content=upgrade&utm_term=description) or premium extension.
+Easy Digital Downloads is backed by top-notch technical support from our globally distributed full-time support team. We also have an [extensive documentation site available](https://easydigitaldownloads.com/docs/?utm_medium=readme&utm_source=wporg&utm_campaign=lite-plugin&utm_content=docs&utm_term=description). If you're looking for faster support via email, we encourage you to [purchase an Easy Digital Downloads pass](https://easydigitaldownloads.com/lite-upgrade/?utm_medium=readme&utm_source=wporg&utm_campaign=lite-plugin&utm_content=upgrade&utm_term=description) or premium extension.
 
 > EDD has been a long standing, rock-solid e-commerce solution for WordPress. The team lives and breathes WordPress, understands the platform, and is embedded in the community.
 


### PR DESCRIPTION
This removes strings and logic around old promotional layouts. We should remove any translatable text we don't need any more so we can help translators out a bit.