### PR TITLE
Fix/this month hour by hour

### DIFF
--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -903,15 +903,19 @@ function get_relative_dates_filter_range() {
 function get_dates_filter_hour_by_hour() {
 	$hour_by_hour = false;
 
-	// Retrieve the queried dates
+	// Retrieve the queried dates.
 	$dates = get_dates_filter( 'objects' );
 
-	// Determine graph options
+	// Determine graph options.
 	switch ( $dates['range'] ) {
 		case 'today':
 		case 'yesterday':
 			$hour_by_hour = true;
 			break;
+		case 'this_week':
+		case 'this_month':
+		case 'this_quarter':
+		case 'this_year':
 		case 'other':
 			$difference = ( $dates['end']->getTimestamp() - $dates['start']->getTimestamp() );
 			if ( $difference <= ( DAY_IN_SECONDS * 2 ) ) {
@@ -921,21 +925,6 @@ function get_dates_filter_hour_by_hour() {
 		default:
 			$hour_by_hour = false;
 			break;
-	}
-
-	// Account for the relative queries being in the first 2 days of the range.
-	$relative_ranges = array(
-		'this_week',
-		'this_month',
-		'this_quarter',
-		'this_year',
-	);
-
-	if ( in_array( $dates['range'], $relative_ranges, true ) ) {
-		$difference = ( $dates['end']->getTimestamp() - $dates['start']->getTimestamp() );
-		if ( $difference <= ( DAY_IN_SECONDS * 2 ) ) {
-			$hour_by_hour = true;
-		}
 	}
 
 	return $hour_by_hour;

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -923,6 +923,21 @@ function get_dates_filter_hour_by_hour() {
 			break;
 	}
 
+	// Account for the relative queries being in the first 2 days of the range.
+	$relative_ranges = array(
+		'this_week',
+		'this_month',
+		'this_quarter',
+		'this_year',
+	);
+
+	if ( in_array( $dates['range'], $relative_ranges, true ) ) {
+		$difference = ( $dates['end']->getTimestamp() - $dates['start']->getTimestamp() );
+		if ( $difference <= ( DAY_IN_SECONDS * 2 ) ) {
+			$hour_by_hour = true;
+		}
+	}
+
 	return $hour_by_hour;
 }
 

--- a/tests/reports/data/charts/v2/tests-manifest.php
+++ b/tests/reports/data/charts/v2/tests-manifest.php
@@ -2,6 +2,7 @@
 namespace EDD\Reports\Data\Charts\v2;
 
 use EDD\Reports\Data\Chart_Endpoint;
+use EDD\Reports;
 
 if ( ! class_exists( 'EDD\\Reports\\Init' ) ) {
 	require_once( EDD_PLUGIN_DIR . 'includes/reports/class-init.php' );
@@ -348,6 +349,20 @@ class Manifest_Tests extends \EDD_UnitTestCase {
 			)
 		) );
 
+		$day_by_day   = Reports\get_dates_filter_day_by_day();
+		$hour_by_hour = Reports\get_dates_filter_hour_by_hour();
+
+		$time_unit   = 'month';
+		$time_format = 'MMM YYYY';
+
+		if ( $hour_by_hour ) {
+			$time_unit   = 'hour';
+			$time_format = 'hA';
+		} elseif ( $day_by_day ) {
+			$time_unit   = 'day';
+			$time_format = 'MMM D';
+		}
+
 		$expected = array(
 			'animation' => array(
 				'duration'   => 0,
@@ -370,8 +385,8 @@ class Manifest_Tests extends \EDD_UnitTestCase {
 						),
 						'position' => 'bottom',
 						'time'     => array(
-							'unit' => 'day',
-							'tooltipFormat' => 'MMM D',
+							'unit'          => $time_unit,
+							'tooltipFormat' => $time_format,
 						),
 					),
 				),


### PR DESCRIPTION
With the changes in #9338, when you are in the first 2 days of the month, the graph is just outputting two data points.

With 'other' if we have only 2 days time diff, we switch to hour by hour, which we should do here as well.