### PR TITLE
Update bundled product validation

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -181,10 +181,10 @@ function edd_sanitize_bundled_products_save( $products = array() ) {
 
 	$products = array_unique( $products );
 
-	return array_combine(
+	return ! empty( $products ) ? array_combine(
 		range( 1, count( $products ) ),
 		array_values( $products )
-	);
+	) : false;
 }
 add_filter( 'edd_metabox_save__edd_bundled_products', 'edd_sanitize_bundled_products_save' );
 
@@ -197,10 +197,10 @@ add_filter( 'edd_metabox_save__edd_bundled_products', 'edd_sanitize_bundled_prod
  * @return array
  */
 function edd_sanitize_bundled_products_conditions_save( $bundled_products_conditions = array() ) {
-	return array_combine(
+	return ! empty( $bundled_products_conditions ) ? array_combine(
 		range( 1, count( $bundled_products_conditions ) ),
 		array_values( $bundled_products_conditions )
-	);
+	) : false;
 }
 add_filter( 'edd_metabox_save__edd_bundled_products_conditions', 'edd_sanitize_bundled_products_conditions_save' );
 


### PR DESCRIPTION
Fixes #9343

Proposed Changes:
1. Updates the bundled products and bundled product conditions to not use array_combine if the array is empty.

Note that the conditions are always going to have one array key/value, even for a download that's not a bundle, because the form is just hidden (so it's still submitted and the default is `all`). That feels a little wonky but it's how it's been forever.