### PR TITLE
Schedule Email Summary event immediately after email is sent out

### DIFF
--- a/includes/emails/email-summary/class-edd-email-summary-cron.php
+++ b/includes/emails/email-summary/class-edd-email-summary-cron.php
@@ -156,6 +156,9 @@ class EDD_Email_Summary_Cron {
 
 		$email = new EDD_Email_Summary();
 		$email->send_email();
+
+		// Schedule the next event.
+		$this->schedule_cron_events();
 	}
 
 }


### PR DESCRIPTION
Small improvement, so that the next Email Summary cron is scheduled immediately after an email has been sent out, instead of waiting for the next `edd_daily_scheduled_events` event to be run.