### PR TITLE
Skip adjustments, adjustmentmeta when resetting store

### DIFF
--- a/includes/admin/tools/class-edd-tools-reset-stats.php
+++ b/includes/admin/tools/class-edd-tools-reset-stats.php
@@ -189,15 +189,20 @@ class EDD_Tools_Reset_Stats extends EDD_Batch_Export {
 				// Objects
 				$object = $component->get_interface( 'table' );
 				if ( $object instanceof \EDD\Database\Table && $object->exists() ) {
+					if ( 'adjustments' === $object->name ) {
+						continue;
+					}
 					$tables[] = $object->table_name;
 				}
 
 				// Meta
 				$meta = $component->get_interface( 'meta' );
 				if ( $meta instanceof \EDD\Database\Table && $meta->exists() ) {
+					if ( 'adjustmentmeta' === $meta->name ) {
+						continue;
+					}
 					$tables[] = $meta->table_name;
 				}
-
 			}
 
 			$tables = apply_filters( 'edd_reset_tables_to_truncate', $tables );


### PR DESCRIPTION
Fixes #9460

Proposed Changes:
1. When resetting the store data, removes the `edd_adjustments` and `edd_adjustmentmeta` tables from the array of tables to reset.