### PR TITLE
Run maybe_upgrade for customers, customer meta during CLI

### DIFF
--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -1277,6 +1277,12 @@ class EDD_CLI extends WP_CLI_Command {
 
 		$this->maybe_install_v3_tables();
 
+		$customers = new EDD\Database\Tables\Customers();
+		$customers->maybe_upgrade();
+
+		$meta = new EDD\Database\Tables\Customer_Meta();
+		$meta->maybe_upgrade();
+
 		require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/v3/class-data-migrator.php';
 
 		$force = isset( $assoc_args['force'] )


### PR DESCRIPTION
Proposed Changes:
1. This runs the `maybe_upgrade` routine for the customers and customer meta tables at the beginning of the CLI customer migration, in case the migration is happening without having touched `admin_init`.