### PR TITLE
Use price assignment keys as saved when getting bundled downloads

### DIFF
--- a/includes/class-edd-download.php
+++ b/includes/class-edd-download.php
@@ -569,10 +569,9 @@ class EDD_Download {
 		}
 
 		$price_assignments = $price_assignments[0];
-		$price_assignments = array_values( $price_assignments );
 
 		foreach ( $price_assignments as $key => $value ) {
-			if ( $value == $price_id || $value == 'all' ) {
+			if ( isset( $bundled_downloads[ $key ] ) && ( $value == $price_id || $value == 'all' ) ) {
 				$downloads[] = $bundled_downloads[ $key ];
 			}
 		}


### PR DESCRIPTION
Fixes #9343

Proposed Changes:
1. Updates the `get_variable_priced_bundled_downloads` download method to not revise the bundled conditions array when matching to the bundled products. Also adds a defensive condition to ensure that the product exists.

I encountered this error with release/3.1 and trying to sell a bundled product with licenses. The last product in the bundle did not get a license generated and running the retroactive processor generated this error:

> PHP Warning:  Undefined array key 0 in \plugins\easy-digital-downloads\includes\class-edd-download.php on line 576