### PR TITLE
Fix/get activation date

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1822,10 +1822,9 @@ function edd_get_activation_date() {
 				)
 			);
 			if ( $orders ) {
-				$first_order = reset( $orders );
-				// Use just the date_created, rather than looking for the completed date (first order may not be complete).
-				if ( ! empty( $first_order->date_created ) ) {
-					$activation_date = strtotime( $first_order->date_created );
+				$first_order_date = reset( $orders );
+				if ( ! empty( $first_order_date ) ) {
+					$activation_date = strtotime( $first_order_date );
 				}
 			}
 		}

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1818,12 +1818,12 @@ function edd_get_activation_date() {
 					'number'  => 1,
 					'orderby' => 'id',
 					'order'   => 'ASC',
-					'type'    => 'sale',
+					'fields'  => 'date_created',
 				)
 			);
 			if ( $orders ) {
 				$first_order = reset( $orders );
-				// Use just the post date, rather than looking for the completed date (first payment may not be complete).
+				// Use just the date_created, rather than looking for the completed date (first order may not be complete).
 				if ( ! empty( $first_order->date_created ) ) {
 					$activation_date = strtotime( $first_order->date_created );
 				}


### PR DESCRIPTION
Due to the load order of `edd_install`, it is possible for the check to get the orders for activation date detection prior to the table existing.

To replicate:
1. Setup a clean WordPress Installation
2. Install EDD from .zip [easy-digital-downloads.zip](https://github.com/awesomemotive/easy-digital-downloads/files/9729258/easy-digital-downloads.zip) but do not activate it.
3. Go to the plugins list and activate EDD.

You will see that it produces a notice about unexpected output.


Adjusts the `edd_get_activation_date` function to first check for the Table existing, and then also updates it to use the `edd_get_orders` function instead of payments.