### PR TITLE
Add a permalink value to the products endpoint #9488

### DIFF
--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -1157,7 +1157,7 @@ class EDD_API {
 		$product['info']['modified_date'] = $product_info->post_modified;
 		$product['info']['status']        = $product_info->post_status;
 		$product['info']['link']          = html_entity_decode( $product_info->guid );
-		$product['info']['permalink']     = get_permalink( $product_info->ID );
+		$product['info']['permalink']     = html_entity_decode( get_permalink( $product_info->ID ) );
 		$product['info']['content']       = $product_info->post_content;
 		$product['info']['excerpt']       = $product_info->post_excerpt;
 		$product['info']['thumbnail']     = wp_get_attachment_url( get_post_thumbnail_id( $product_info->ID ) );

--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -1157,6 +1157,7 @@ class EDD_API {
 		$product['info']['modified_date'] = $product_info->post_modified;
 		$product['info']['status']        = $product_info->post_status;
 		$product['info']['link']          = html_entity_decode( $product_info->guid );
+		$product['info']['permalink']     = get_permalink( $product_info->ID );
 		$product['info']['content']       = $product_info->post_content;
 		$product['info']['excerpt']       = $product_info->post_excerpt;
 		$product['info']['thumbnail']     = wp_get_attachment_url( get_post_thumbnail_id( $product_info->ID ) );

--- a/tests/tests-api.php
+++ b/tests/tests-api.php
@@ -288,7 +288,7 @@ class Tests_API extends EDD_UnitTestCase {
 		$this->assertEquals( self::$post->post_content, $out['products'][0]['info']['content'] );
 		$this->assertEquals( '', $out['products'][0]['info']['thumbnail'] );
 		$this->assertEquals( html_entity_decode( self::$post->guid ), $out['products'][0]['info']['link'] );
-		$this->assertEquals( get_permalink( self::$post->ID ), $out['products'][0]['info']['permalink'] );
+		$this->assertEquals( html_entity_decode( get_permalink( self::$post->ID ) ), $out['products'][0]['info']['permalink'] );
 	}
 
 	public function test_get_product_stats() {

--- a/tests/tests-api.php
+++ b/tests/tests-api.php
@@ -277,6 +277,7 @@ class Tests_API extends EDD_UnitTestCase {
 		$this->assertArrayHasKey( 'modified_date', $out['products'][0]['info'] );
 		$this->assertArrayHasKey( 'status', $out['products'][0]['info'] );
 		$this->assertArrayHasKey( 'link', $out['products'][0]['info'] );
+		$this->assertArrayHasKey( 'permalink', $out['products'][0]['info'] );
 		$this->assertArrayHasKey( 'content', $out['products'][0]['info'] );
 		$this->assertArrayHasKey( 'thumbnail', $out['products'][0]['info'] );
 
@@ -286,6 +287,8 @@ class Tests_API extends EDD_UnitTestCase {
 		$this->assertEquals( 'publish', $out['products'][0]['info']['status'] );
 		$this->assertEquals( self::$post->post_content, $out['products'][0]['info']['content'] );
 		$this->assertEquals( '', $out['products'][0]['info']['thumbnail'] );
+		$this->assertEquals( html_entity_decode( self::$post->guid ), $out['products'][0]['info']['link'] );
+		$this->assertEquals( get_permalink( self::$post->ID ), $out['products'][0]['info']['permalink'] );
 	}
 
 	public function test_get_product_stats() {


### PR DESCRIPTION
Fixes #9488 

Proposed Changes:
1. Adds a new 'permalink' item to the product data for the `products` API Endpoint.
2. Adds unit tests for the `link` and `permalink` data endpoints.