### PR TITLE
Allow entire variable product to be selected for a bundle

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -596,7 +596,7 @@ function edd_render_products_field( $post_id ) {
 												'chosen'               => true,
 												'bundles'              => false,
 												'variations'           => true,
-												'show_variations_only' => true,
+												'show_variations_only' => false,
 												'class'                => 'edd-form-group__input',
 											)
 										);

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -665,7 +665,7 @@ function edd_render_products_field( $post_id ) {
 										'chosen'               => true,
 										'bundles'              => false,
 										'variations'           => true,
-										'show_variations_only' => true,
+										'show_variations_only' => false,
 									) );
 									?>
 									</div>


### PR DESCRIPTION
Fixes #9499

Proposed Changes:
1. Updates the product selector for bundled downloads to include the overall product in addition to each variations.