### PR TITLE
Restrict the ajax downloads search to titles only

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -743,6 +743,7 @@ function edd_ajax_filter_download_where( $where, $wp_query ) {
 	$search = $wp_query->get( 'edd_search' );
 	if ( $search ) {
 		global $wpdb;
+		$search = $wpdb->esc_like( $search );
 		$where .= " AND {$wpdb->posts}.post_title LIKE '%{$search}%'";
 	}
 

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -682,6 +682,7 @@ function edd_ajax_download_search() {
 
 		// Loop through all items...
 		foreach ( $items as $post_id => $title ) {
+			$product_title = $title;
 
 			// Look for variable pricing
 			$prices = edd_get_variable_prices( $post_id );
@@ -694,7 +695,7 @@ function edd_ajax_download_search() {
 				// Add item to results array
 				$search['results'][] = array(
 					'id'   => $post_id,
-					'name' => $title
+					'name' => $title,
 				);
 			}
 
@@ -706,7 +707,7 @@ function edd_ajax_download_search() {
 					if ( ! empty( $name ) ) {
 						$search['results'][] = array(
 							'id'   => $post_id . '_' . $key,
-							'name' => esc_html( $title . ': ' . $name ),
+							'name' => esc_html( $product_title . ': ' . $name ),
 						);
 					}
 				}


### PR DESCRIPTION
Fixes #9508

Proposed Changes:
1. Adds a filter on the `WHERE` clause for the ajax downloads search. This restricts the search to run on the download titles only, instead of including the content and excerpt.