### PR TITLE
Update customer table upgrade checks

### DIFF
--- a/includes/database/tables/class-customer-meta.php
+++ b/includes/database/tables/class-customer-meta.php
@@ -104,7 +104,7 @@ final class Customer_Meta extends Table {
 	 * @return bool
 	 */
 	private function needs_initial_upgrade() {
-		return $this->exists() && $this->column_exists( 'customer_id' ) && ! $this->column_exists( 'edd_customer_id' );
+		return $this->exists() && $this->column_exists( 'customer_id' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #9462

Proposed Changes:
1. This moves the new columns creation and checks to the beginning of the upgrade function, and then runs the alter queries if any of the columns were missing.
