### PR TITLE
Update customer address migration

### DIFF
--- a/includes/admin/upgrades/v3/class-customer-addresses.php
+++ b/includes/admin/upgrades/v3/class-customer-addresses.php
@@ -92,8 +92,7 @@ class Customer_Addresses extends Base {
 				SET ca.is_primary = 1
 				WHERE ca.id IN (
 					SELECT MAX(ca2.id)
-					FROM ( SELECT * FROM {$this->get_db()->edd_customer_addresses} ) ca2
-					WHERE ca2.type = 'billing'
+					FROM ( SELECT id, customer_id FROM {$this->get_db()->edd_customer_addresses} WHERE type = 'billing' ) ca2
 					GROUP BY ca2.customer_id
 				)
 			";

--- a/includes/admin/upgrades/v3/class-customer-addresses.php
+++ b/includes/admin/upgrades/v3/class-customer-addresses.php
@@ -92,7 +92,7 @@ class Customer_Addresses extends Base {
 				SET ca.is_primary = 1
 				WHERE ca.id IN (
 					SELECT MAX(ca2.id)
-					FROM ( SELECT id, customer_id FROM {$this->get_db()->edd_customer_addresses} WHERE type = 'billing' ) ca2
+					FROM ( SELECT id, customer_id FROM {$this->get_db()->edd_customer_addresses} WHERE ca.type = 'billing' ) ca2
 					GROUP BY ca2.customer_id
 				)
 			";

--- a/includes/admin/upgrades/v3/class-customer-addresses.php
+++ b/includes/admin/upgrades/v3/class-customer-addresses.php
@@ -85,21 +85,6 @@ class Customer_Addresses extends Base {
 			$percentage = 100;
 		}
 
-		if ( 100 === $percentage ) {
-			// Now update the most recent billing address entries for customers as the primary address.
-			$sql = "
-				UPDATE {$this->get_db()->edd_customer_addresses} ca
-				SET ca.is_primary = 1
-				WHERE ca.id IN (
-					SELECT MAX(ca2.id)
-					FROM ( SELECT id, customer_id FROM {$this->get_db()->edd_customer_addresses} WHERE type = 'billing' ) ca2
-					GROUP BY ca2.customer_id
-				)
-			";
-
-			@$this->get_db()->query( $sql );
-		}
-
 		return $percentage;
 	}
 }

--- a/includes/admin/upgrades/v3/class-customer-addresses.php
+++ b/includes/admin/upgrades/v3/class-customer-addresses.php
@@ -92,7 +92,7 @@ class Customer_Addresses extends Base {
 				SET ca.is_primary = 1
 				WHERE ca.id IN (
 					SELECT MAX(ca2.id)
-					FROM ( SELECT id, customer_id FROM {$this->get_db()->edd_customer_addresses} WHERE ca.type = 'billing' ) ca2
+					FROM ( SELECT id, customer_id FROM {$this->get_db()->edd_customer_addresses} WHERE type = 'billing' ) ca2
 					GROUP BY ca2.customer_id
 				)
 			";

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -60,7 +60,7 @@ class Data_Migrator {
 		}
 
 		if ( $customer ) {
-			edd_add_customer_address(
+			edd_maybe_add_customer_address(
 				array(
 					'customer_id'  => $customer->id,
 					'is_primary'   => true,

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -1379,20 +1379,6 @@ class EDD_CLI extends WP_CLI_Command {
 			}
 
 			$progress->tick();
-
-			// Now update the most recent billing address entries for customers as the primary address.
-			$sql = "
-				UPDATE {$wpdb->edd_customer_addresses} ca
-				SET ca.is_primary = 1
-				WHERE ca.id IN (
-					SELECT MAX(ca2.id)
-					FROM ( SELECT id, customer_id FROM {$wpdb->edd_customer_addresses} WHERE type = 'billing' ) ca2
-					GROUP BY ca2.customer_id
-				)
-			";
-
-			@$wpdb->query( $sql );
-
 			$progress->finish();
 
 			edd_set_upgrade_complete( 'migrate_customer_addresses' );

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -1386,7 +1386,7 @@ class EDD_CLI extends WP_CLI_Command {
 				SET ca.is_primary = 1
 				WHERE ca.id IN (
 					SELECT MAX(ca2.id)
-					FROM ( SELECT * FROM {$wpdb->edd_customer_addresses} ) ca2
+					FROM ( SELECT id, customer_id FROM {$wpdb->edd_customer_addresses} WHERE type = 'billing' ) ca2
 					WHERE ca2.type = 'billing'
 					GROUP BY ca2.customer_id
 				)

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -1386,7 +1386,7 @@ class EDD_CLI extends WP_CLI_Command {
 				SET ca.is_primary = 1
 				WHERE ca.id IN (
 					SELECT MAX(ca2.id)
-					FROM ( SELECT id, customer_id FROM {$wpdb->edd_customer_addresses} WHERE ca.type = 'billing' ) ca2
+					FROM ( SELECT id, customer_id FROM {$wpdb->edd_customer_addresses} WHERE type = 'billing' ) ca2
 					GROUP BY ca2.customer_id
 				)
 			";

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -1386,8 +1386,7 @@ class EDD_CLI extends WP_CLI_Command {
 				SET ca.is_primary = 1
 				WHERE ca.id IN (
 					SELECT MAX(ca2.id)
-					FROM ( SELECT id, customer_id FROM {$wpdb->edd_customer_addresses} WHERE type = 'billing' ) ca2
-					WHERE ca2.type = 'billing'
+					FROM ( SELECT id, customer_id FROM {$wpdb->edd_customer_addresses} WHERE ca.type = 'billing' ) ca2
 					GROUP BY ca2.customer_id
 				)
 			";


### PR DESCRIPTION
Fixes #9480

Proposed Changes:
This PR does a couple things:
1. Updates the customer address migration to use `edd_maybe_add_customer_address` to prevent duplicate addresses being added. On a test site, this reduced the number of addresses from 22k to 13.7k.
2. Updates the final query to check/update the address type.