### PR TITLE
Separate product query for dropdowns

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -559,7 +559,13 @@ function edd_render_products_field( $post_id ) {
 	$variable_pricing = $download->has_variable_prices();
 	$variable_display = $variable_pricing ? '' : 'display:none;';
 	$variable_class   = $variable_pricing ? ' has-variable-pricing' : '';
-	$prices           = $download->get_prices(); ?>
+	$prices           = $download->get_prices();
+	$bundle_options   = EDD()->html->get_products(
+		array(
+			'bundles' => false,
+		)
+	);
+	?>
 
 	<div id="edd_products"<?php echo $display; ?>>
 		<div id="edd_file_fields_bundle" class="edd_meta_table_wrap">
@@ -594,7 +600,7 @@ function edd_render_products_field( $post_id ) {
 												'selected'             => $product,
 												'multiple'             => false,
 												'chosen'               => true,
-												'bundles'              => false,
+												'products'             => $bundle_options,
 												'variations'           => true,
 												'show_variations_only' => false,
 												'class'                => 'edd-form-group__input',
@@ -663,7 +669,7 @@ function edd_render_products_field( $post_id ) {
 										'id'                   => 'edd_bundled_products_1',
 										'multiple'             => false,
 										'chosen'               => true,
-										'bundles'              => false,
+										'products'             => $bundle_options,
 										'variations'           => true,
 										'show_variations_only' => false,
 									) );


### PR DESCRIPTION
Proposed Changes:
1. Creates a new `get_products` method in the HTML elements class, to allow the products to be retrieved separately from rendering the product dropdown.
2. Implements the new method for the download metabox for bundled products.