### PR TITLE
Fix empty check for REST user query

### DIFF
--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -555,7 +555,7 @@ add_filter( 'display_post_states', 'edd_display_post_states', 10, 2 );
  */
 function edd_add_custom_roles_rest_user_query( $prepared_args, $request ) {
 	// If the args don't match the authors query, return early.
-	if ( empty( $prepared_args['who'] || 'authors' !== $prepared_args['who'] ) ) {
+	if ( empty( $prepared_args['who'] ) || 'authors' !== $prepared_args['who'] ) {
 		return $prepared_args;
 	}
 


### PR DESCRIPTION
Related: https://github.com/awesomemotive/edd-fes/issues/1678

This just moves the closing `)` to where it should be in the empty check for the REST user query.