### PR TITLE
Re: Issue #9443 -- Improved price_id handling

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1122,7 +1122,11 @@ function edd_get_item_discount_amount( $item, $items, $discounts, $item_unit_pri
 					foreach ( $items as $i ) {
 						if ( ! in_array( $i['id'], $excluded_products ) ) {
 							if ( edd_has_variable_prices( $i['id'] ) ) {
-								$i_amount = edd_get_price_option_amount( $i['id'], $i['options']['price_id'] );
+								if( isset($i['options']) ){
+									$i_amount = edd_get_price_option_amount( $i['id'], $i['options']['price_id'] );
+								}else{
+									$i_amount = edd_get_price_option_amount( $i['id'], $i['item_number']['options']['price_id'] );
+								}
 							} else {
 								$i_amount = edd_get_download_price( $i['id'] );
 							}


### PR DESCRIPTION
- not all cart items are set with an "options" array
- in many cases, cart items instead use a "item_number" array
- safely check if this item has "options" if not, use the latter

Fixes #9443 

Proposed Changes:
1. Check cart item to see if it has 'options' array available
2. If not, grab the 'price_id' by means of the commonly used ['item_number']['options'] array
