### PR TITLE
Update discount migration to allow for custom metadata

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -175,7 +175,7 @@ class Data_Migrator {
 		$args            = array();
 		$meta            = get_post_custom( $data->ID );
 		$meta_to_migrate = array();
-		$meta_to_ignore  = array(
+		$core_meta       = array(
 			'code',
 			'name',
 			'status',
@@ -202,7 +202,7 @@ class Data_Migrator {
 				continue;
 			}
 			$meta_key = str_replace( '_edd_discount_', '', $key );
-			if ( ! in_array( $meta_key, $meta_to_ignore, true ) ) {
+			if ( ! in_array( $meta_key, $core_meta, true ) ) {
 				$meta_to_migrate[ $meta_key ] = $value;
 				continue;
 			}

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -175,17 +175,39 @@ class Data_Migrator {
 		$args            = array();
 		$meta            = get_post_custom( $data->ID );
 		$meta_to_migrate = array();
+		$meta_to_ignore  = array(
+			'code',
+			'name',
+			'status',
+			'uses',
+			'max_uses',
+			'amount',
+			'start',
+			'expiration',
+			'type',
+			'min_price',
+			'product_reqs',
+			'product_condition',
+			'excluded_products',
+			'is_not_global',
+			'is_single_use',
+		);
 
 		foreach ( $meta as $key => $value ) {
+			$value = maybe_unserialize( $value[0] );
 			if ( false === strpos( $key, '_edd_discount' ) ) {
 
 				// This is custom meta from another plugin that needs to be migrated to the new meta table.
-				$meta_to_migrate[ $key ] = maybe_unserialize( $value[0] );
+				$meta_to_migrate[ $key ] = $value;
+				continue;
+			}
+			$meta_key = str_replace( '_edd_discount_', '', $key );
+			if ( ! in_array( $meta_key, $meta_to_ignore, true ) ) {
+				$meta_to_migrate[ $meta_key ] = $value;
 				continue;
 			}
 
-			$value = maybe_unserialize( $value[0] );
-			$args[ str_replace( '_edd_discount_', '', $key ) ] = $value;
+			$args[ $meta_key ] = $value;
 		}
 
 		// If the discount name was not stored in post_meta, use value from the WP_Post object.

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -893,6 +893,12 @@ class EDD_CLI extends WP_CLI_Command {
 			? true
 			: false;
 
+		$destroy = (bool) ( $force && isset( $assoc_args['destroy'] ) );
+
+		if ( $destroy ) {
+			WP_CLI::confirm( __( 'This process will remove and recreate discounts in your database. Please make sure you\'ve backed up your EDD database tables. Are you sure you want to delete discounts that have already been migrated and run the migration again?', 'easy-digital-downloads' ) );
+		}
+
 		$upgrade_completed = edd_has_upgrade_completed( 'migrate_discounts' );
 
 		if ( ! $force && $upgrade_completed ) {
@@ -908,6 +914,9 @@ class EDD_CLI extends WP_CLI_Command {
 			$progress = new \cli\progress\Bar( 'Migrating Discounts', $total );
 
 			foreach ( $results as $result ) {
+				if ( $destroy ) {
+					edd_delete_discount( $result->ID );
+				}
 				\EDD\Admin\Upgrades\v3\Data_Migrator::discounts( $result );
 
 				$progress->tick();

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -58,7 +58,7 @@ function edd_add_discount( $data = array() ) {
 			}
 
 			if ( is_array( $product_requirements ) ) {
-				foreach ( $product_requirements as $product_requirement ) {
+				foreach ( array_filter( $product_requirements ) as $product_requirement ) {
 					edd_add_adjustment_meta( $discount_id, 'product_requirement', $product_requirement );
 				}
 			}
@@ -71,7 +71,7 @@ function edd_add_discount( $data = array() ) {
 			}
 
 			if ( is_array( $excluded_products ) ) {
-				foreach ( $excluded_products as $excluded_product ) {
+				foreach ( array_filter( $excluded_products ) as $excluded_product ) {
 					edd_add_adjustment_meta( $discount_id, 'excluded_product', $excluded_product );
 				}
 			}


### PR DESCRIPTION
Fixes #9531

Proposed Changes:
1. This updates the `discounts` method in the data migrator class to explicitly check any post meta with the `_edd_discount` prefix against the core meta/properties for discounts.
2. If existing meta is not a core property, it should be added to the new discount object's metadata.

To Test:
This could be tested by using the gist linked in the original issue to add some custom meta to a discount for handling discounts on subscriptions.
1. Create the discount in EDD 2.11, making sure that the custom meta is saved to the discount.
2. Migrate the discount to EDD 3.0. In the main branch, that custom meta will be lost; in this branch, it should persist (whether the linked code works in 3.0 is a separate issue as I think it uses some post functions which may not be compatible).
3. This could also be tested with this PR in Recurring: https://github.com/awesomemotive/edd-recurring/pull/1661