### PR TITLE
Revise can_purchase check for unpublished downloads

### DIFF
--- a/includes/class-edd-download.php
+++ b/includes/class-edd-download.php
@@ -873,7 +873,7 @@ class EDD_Download {
 	public function can_purchase() {
 		$can_purchase = true;
 
-		if ( ! current_user_can( 'edit_post', $this->ID ) && $this->post_status != 'publish' ) {
+		if ( 'publish' !== $this->post_status && ! current_user_can( 'edit_post', $this->ID ) ) {
 			$can_purchase = false;
 		}
 


### PR DESCRIPTION
Fixes #9542

Proposed Changes:
1. Updates the `$download->can_purchase` check to check post status before capability.