### PR TITLE
Improve edd_has_active_discounts for performance and accuracy #9526

### DIFF
--- a/includes/admin/discounts/discount-actions.php
+++ b/includes/admin/discounts/discount-actions.php
@@ -55,7 +55,6 @@ function edd_admin_add_discount( $data = array() ) {
 	// Setup default discount values.
 	$to_add            = array();
 	$to_add['status']  = 'active';
-	$current_timestamp = current_time( 'timestamp' );
 
 	$data = array_filter( $data );
 
@@ -142,6 +141,11 @@ function edd_admin_add_discount( $data = array() ) {
 		? 'discount_added'
 		: 'discount_add_failed';
 
+	if ( ! empty( $created ) ) {
+		// Now re-prime the transient for the has_acitve_discounts check
+		edd_has_active_discounts( 50, true );
+	}
+
 	// Redirect.
 	edd_redirect( add_query_arg( 'edd-message', sanitize_key( $arg ), $data['edd-redirect'] ) );
 }
@@ -186,7 +190,6 @@ function edd_admin_edit_discount( $data = array() ) {
 
 	// Prepare update
 	$to_update    = array();
-	$current_time = current_time( 'timestamp' );
 
 	$data = array_filter( $data );
 
@@ -284,6 +287,11 @@ function edd_admin_edit_discount( $data = array() ) {
 		? 'discount_updated'
 		: 'discount_not_changed';
 
+	if ( ! empty( $updated ) ) {
+		// Now re-prime the transient for the has_acitve_discounts check
+		edd_has_active_discounts( 50, true );
+	}
+
 	// Redirect
 	edd_redirect( add_query_arg( 'edd-message', sanitize_key( $arg ), $data['edd-redirect'] ) );
 }
@@ -322,6 +330,11 @@ function edd_admin_delete_discount( $data = array() ) {
 		? 'discount_deleted'
 		: 'discount_deleted_failed';
 
+	if ( ! empty( $deleted ) ) {
+		// Now re-prime the transient for the has_acitve_discounts check
+		edd_has_active_discounts( 50, true );
+	}
+
 	// Redirect
 	edd_redirect( remove_query_arg( 'edd-action', add_query_arg( 'edd-message', sanitize_key( $arg ), $_SERVER['REQUEST_URI'] ) ) );
 }
@@ -355,6 +368,11 @@ function edd_activate_discount( $data = array() ) {
 		? 'discount_activated'
 		: 'discount_activation_failed';
 
+	if ( ! empty( $activated ) ) {
+		// Now re-prime the transient for the has_acitve_discounts check
+		edd_has_active_discounts( 50, true );
+	}
+
 	// Redirect
 	edd_redirect( remove_query_arg( 'edd-action', add_query_arg( 'edd-message', sanitize_key( $arg ), $_SERVER['REQUEST_URI'] ) ) );
 }
@@ -383,12 +401,50 @@ function edd_deactivate_discount( $data = array() ) {
 	}
 
 	$discount_id = absint( $data['discount'] );
-	$activated   = edd_update_discount_status( $discount_id, 'inactive' );
-	$arg         = ! empty( $activated )
+	$deactivated = edd_update_discount_status( $discount_id, 'inactive' );
+	$arg         = ! empty( $deactivated )
 		? 'discount_deactivated'
 		: 'discount_deactivation_failed';
+
+	if ( ! empty( $deactivated ) ) {
+		// Now re-prime the transient for the has_acitve_discounts check
+		edd_has_active_discounts( 50, true );
+	}
 
 	// Redirect
 	edd_redirect( remove_query_arg( 'edd-action', add_query_arg( 'edd-message', sanitize_key( $arg ), $_SERVER['REQUEST_URI'] ) ) );
 }
 add_action( 'edd_deactivate_discount', 'edd_deactivate_discount' );
+
+/**
+ * When running the after payment actions, checks if the order had discounts and if it does, refreshes the edd_has_active_discounts transient.
+ *
+ * @since 3.1.0.3
+ *
+ * @param int         $order_id       The order ID being processed
+ * @param EDD_Payment $payment_object The EDD_Payment object being processed.
+ * @param EDD_Customer $customer      The EDD_Customer object from the order.
+ *
+ * @uses edd_has_active_discounts()
+ *
+ * @return void
+ */
+function edd_refresh_has_active_discounts_on_complete( $order_id, $payment_object, $customer ) {
+	$order_adjustments = edd_get_order_adjustments(
+		array(
+			'object_id'   => $order_id,
+			'object_type' => 'order',
+			'type'        => 'discount',
+		)
+	);
+
+	// If there were no discount adjustments on this order, just bail.
+	if ( empty( $order_adjustments ) ) {
+		return;
+	}
+
+	// Since we are running this outside of the userspace, use a large integer.
+	edd_has_active_discounts( 50, true );
+
+}
+add_action( 'edd_after_payment_actions', 'edd_refresh_has_active_discounts_on_complete', 10, 3 );

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -373,31 +373,50 @@ function edd_get_discount_notes( $discount_id = 0 ) {
  *
  * @since 1.0
  * @since 3.0 Updated to be more efficient and make direct calls to the EDD_Discount object.
+ * @since 3.1.0.3 Added Sample size and Refresh parameters to be able to cache the result as a transient.
+ *
+ * @param int  $sample_size The number of discount codes to query. Defaults to 10 for performance.
+ * @param bool $refresh     If we should force a refresh of the transient. Defaults to false.
  *
  * @return bool
  */
-function edd_has_active_discounts() {
+function edd_has_active_discounts( $sample_size = 10, $refresh = false ) {
+
+	// If we are not forcing a refresh of the value, check the transient.
+	if ( false === $refresh ) {
+		$cached_result = get_transient( 'edd_has_active_discounts' );
+
+		if ( false !== $cached_result  ) {
+			return boolval( $cached_result );
+		}
+	}
 
 	// Query for active discounts.
 	$discounts = edd_get_discounts( array(
-		'number' => 10,
+		'number' => $sample_size,
 		'status' => 'active'
 	) );
 
 	// Bail if none.
 	if ( empty( $discounts ) ) {
-		return false;
-	}
-
-	// Check each discount for active status, applying filters, etc...
-	foreach ( $discounts as $discount ) {
-		/** @var $discount EDD_Discount */
-		if ( $discount->is_active( false, true ) ) {
-			return true;
+		$has_active_discounts = false;
+	} else {
+		// Check each discount for active status, applying filters, etc...
+		foreach ( $discounts as $discount ) {
+			/** @var $discount EDD_Discount */
+			if ( $discount->is_active( false, true ) ) {
+				$has_active_discounts = true;
+				break;
+			}
 		}
 	}
 
-	return false;
+	// Set a 5 minute transient.
+	$transient_value = $has_active_discounts ? 1 : 0;
+	$expiration_time = apply_filters( 'edd_has_active_discount_transient_expiration', 5 * MINUTE_IN_SECONDS );
+	set_transient( 'edd_has_active_discounts', $transient_value, $expiration_time );
+
+	return $has_active_discounts;
 }
 
 /**


### PR DESCRIPTION
Fixes #9526 

Proposed Changes:
1. Adds 2 parameters to `edd_has_active_discounts`
1a. `$sample_size` (Default: `10`). Serves as a way to increase the number of discounts queried to determine active discounts, depending on the context. 
1b. `$refresh` (Default: `false`). Serves as a way to force updating the new transient (see 2)
2. Adds a new transient `edd_has_active_discounts`. This stores as a `1` or `0` depending on if we find active discounts for the store. The transient has a filterable 5 minute expiration time.
3. Updates All admin based actions for discounts (add, update, activate, deactivate, delete), to force a refresh if the action was successful, with a sample size of `50` to help improve accuracy.
4. Adds a hook into the `edd_after_payment_actions` and if the oder being processed had `discount` adjustments on it, we force the refresh of the transient, with 50 as the sample size.

While the 5 minute transient may seem long, keep in mind a few things.

Any order that is processed will run the after payment actions, and update the transient. Any action by an admin to edit a discount will also refresh the transient.