### PR TITLE
When searching orders by product ID, remove the hash before running intval #9548

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -964,7 +964,7 @@ class EDD_Payment_History_Table extends List_Table {
 
 		// Download ID
 		if ( is_string( $search ) && ( false !== strpos( $search, '#' ) ) ) {
-			$args['product_id'] = absint( $search );
+			$args['product_id'] = intval( trim( str_replace( '#', '', $search ) ) );
 
 			return $args;
 		}


### PR DESCRIPTION
Fixes #9548 

Proposed Changes:
1. Runs the search query through `str_replace` to remove the `#` character for `product_id` searches, and then runs `trim` and `invtal`