### PR TITLE
Remove trashed orders from order history, and abandoned/trashed/refunded orders from download history #9556

### DIFF
--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -24,10 +24,11 @@ $page     = get_query_var( 'paged' ) ? get_query_var( 'paged' ) : 1;
 if ( ! empty( $customer ) ) {
 	$orders = edd_get_orders(
 		array(
-			'customer_id' => $customer->id,
-			'number'      => 20,
-			'offset'      => 20 * ( intval( $page ) - 1 ),
-			'type'        => 'sale',
+			'customer_id'    => $customer->id,
+			'number'         => 20,
+			'offset'         => 20 * ( intval( $page ) - 1 ),
+			'type'           => 'sale',
+			'status__not_in' => array( 'trash', 'refunded', 'abandoned' ),
 		)
 	);
 } else {
@@ -116,8 +117,9 @@ if ( $orders ) :
 	if ( ! empty( $customer->id ) ) {
 		$count = edd_count_orders(
 			array(
-				'customer_id' => $customer->id,
-				'type'        => 'sale',
+				'customer_id'    => $customer->id,
+				'type'           => 'sale',
+				'status__not_in' => array( 'trash', 'refunded', 'abandoned' ),
 			)
 		);
 		echo edd_pagination(

--- a/templates/history-purchases.php
+++ b/templates/history-purchases.php
@@ -24,10 +24,11 @@ $page    = get_query_var( 'paged' ) ? get_query_var( 'paged' ) : 1;
 $user_id = get_current_user_id();
 $orders  = edd_get_orders(
 	array(
-		'user_id' => $user_id,
-		'number'  => 20,
-		'offset'  => 20 * ( intval( $page ) - 1 ),
-		'type'    => 'sale',
+		'user_id'        => $user_id,
+		'number'         => 20,
+		'offset'         => 20 * ( intval( $page ) - 1 ),
+		'type'           => 'sale',
+		'status__not_in' => array( 'trash' ),
 	)
 );
 


### PR DESCRIPTION
Fixes #9556 

Proposed Changes:
1. Removes `trash` orders from the Order History shortcode.
2. Removes `trash, refunded, abandoned` orders from the Download History shortcode.
3. Fixes pagination for Download history to also use the same statuses.

_Please do not submit PRs with minified CSS or JS files. This is managed at the time of release by the Core Team_
