### PR TITLE
Exclude trashed orders from exports

### DIFF
--- a/includes/admin/reporting/export/class-batch-export-payments.php
+++ b/includes/admin/reporting/export/class-batch-export-payments.php
@@ -91,12 +91,13 @@ class EDD_Batch_Payments_Export extends EDD_Batch_Export {
 		$data = array();
 
 		$args = array(
-			'number'  => 30,
-			'offset'  => ( $this->step * 30 ) - 30,
-			'status'  => $this->status,
-			'order'   => 'ASC',
-			'orderby' => 'date_created',
-			'type'    => 'sale',
+			'number'         => 30,
+			'offset'         => ( $this->step * 30 ) - 30,
+			'status'         => $this->status,
+			'order'          => 'ASC',
+			'orderby'        => 'date_created',
+			'type'           => 'sale',
+			'status__not_in' => array( 'trash' ),
 		);
 
 		if ( ! empty( $this->start ) || ! empty( $this->end ) ) {

--- a/includes/admin/reporting/export/class-batch-export-payments.php
+++ b/includes/admin/reporting/export/class-batch-export-payments.php
@@ -38,8 +38,8 @@ class EDD_Batch_Payments_Export extends EDD_Batch_Export {
 	 */
 	public function csv_cols() {
 		$cols = array(
-			'id'           => __( 'Payment ID', 'easy-digital-downloads' ), // unaltered payment ID (use for querying)
-			'seq_id'       => __( 'Payment Number', 'easy-digital-downloads' ), // sequential payment ID
+			'id'           => __( 'Order ID', 'easy-digital-downloads' ), // unaltered payment ID (use for querying)
+			'seq_id'       => __( 'Order Number', 'easy-digital-downloads' ), // sequential payment ID
 			'email'        => __( 'Email', 'easy-digital-downloads' ),
 			'customer_id'  => __( 'Customer ID', 'easy-digital-downloads' ),
 			'name'         => __( 'Customer Name', 'easy-digital-downloads' ),

--- a/includes/admin/reporting/export/class-batch-export-taxed-orders.php
+++ b/includes/admin/reporting/export/class-batch-export-taxed-orders.php
@@ -90,11 +90,12 @@ class EDD_Batch_Taxed_Orders_Export extends EDD_Batch_Export {
 		$data = array();
 
 		$args = array(
-			'number'  => 30,
-			'offset'  => ( $this->step * 30 ) - 30,
-			'status'  => $this->status,
-			'order'   => 'ASC',
-			'orderby' => 'date_created',
+			'number'         => 30,
+			'offset'         => ( $this->step * 30 ) - 30,
+			'status'         => $this->status,
+			'order'          => 'ASC',
+			'orderby'        => 'date_created',
+			'status__not_in' => array( 'trash' ),
 		);
 
 		if ( ! empty( $this->start ) || ! empty( $this->end ) ) {


### PR DESCRIPTION
Fixes #9569 

Proposed Changes:
I have excluded `trash` status from order query.