### PR TITLE
Add fallback to item_number and set a default i_amount #9443

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1125,11 +1125,8 @@ function edd_get_item_discount_amount( $item, $items, $discounts, $item_unit_pri
 							$i_amount = 0;
 
 							if ( edd_has_variable_prices( $i['id'] ) ) {
-								if ( isset( $i['options'] ) ) {
-									$i_amount = edd_get_price_option_amount( $i['id'], $i['options']['price_id'] );
-								} elseif ( isset( $i['item_number']['options'] ) ) {
-									$i_amount = edd_get_price_option_amount( $i['id'], $i['item_number']['options']['price_id'] );
-								}
+								$price_id = isset( $i['options']['price_id'] ) ? $i['options']['price_id'] : $i['item_number']['options']['price_id'];
+								$i_amount = edd_get_price_option_amount( $i['id'], $price_id );
 							} else {
 								$i_amount = edd_get_download_price( $i['id'] );
 							}

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1120,9 +1120,16 @@ function edd_get_item_discount_amount( $item, $items, $discounts, $item_unit_pri
 					$items_amount = 0;
 
 					foreach ( $items as $i ) {
+
 						if ( ! in_array( $i['id'], $excluded_products ) ) {
+							$i_amount = 0;
+
 							if ( edd_has_variable_prices( $i['id'] ) ) {
-								$i_amount = edd_get_price_option_amount( $i['id'], $i['options']['price_id'] );
+								if ( isset( $i['options'] ) ) {
+									$i_amount = edd_get_price_option_amount( $i['id'], $i['options']['price_id'] );
+								} elseif ( isset( $i['item_number']['options'] ) ) {
+									$i_amount = edd_get_price_option_amount( $i['id'], $i['item_number']['options']['price_id'] );
+								}
 							} else {
 								$i_amount = edd_get_download_price( $i['id'] );
 							}


### PR DESCRIPTION
Fixes #9443 

Proposed Changes:
1. Adds a default `$i_amount` to `0`
2. Adds checks for the `options` array key, else the `item_number - options` array keys.