### PR TITLE
Add support for togglable "Advanced Settings" in download file metabox row

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -790,6 +790,9 @@ add_action( 'edd_meta_box_files_fields', 'edd_render_files_field', 20 );
  * Used to output a table row for each file associated with a download.
  * Can be called directly, or attached to an action.
  *
+ * Added support for advanced settings with the the edd_download_file_option_row
+ * action hook (@since 3.1.0.3).
+ *
  * @since 1.2.2
  * @param string $key Array key
  * @param array $args Array of all the arguments passed to the function
@@ -797,6 +800,7 @@ add_action( 'edd_meta_box_files_fields', 'edd_render_files_field', 20 );
  * @return void
  */
 function edd_render_file_row( $key, $args, $post_id, $index ) {
+	global $wp_filter;
 
 	$args = wp_parse_args( $args, array(
 		'name'           => null,
@@ -806,20 +810,27 @@ function edd_render_file_row( $key, $args, $post_id, $index ) {
 		'thumbnail_size' => null,
 	) );
 
-	$prices           = edd_get_variable_prices( $post_id );
-	$variable_pricing = edd_has_variable_prices( $post_id );
-	$variable_display = $variable_pricing ? '' : ' style="display:none;"';
-	$variable_class   = $variable_pricing ? ' has-variable-pricing' : ''; ?>
+	$prices           		= edd_get_variable_prices( $post_id );
+	$variable_pricing 		= edd_has_variable_prices( $post_id );
+	$variable_display 		= $variable_pricing ? '' : ' style="display:none;"';
+	$variable_class   		= $variable_pricing ? ' has-variable-pricing' : '';
+	$custom_file_options 	= isset( $wp_filter['edd_download_file_option_row'] ) ? true : false; ?>
 
 	<div class="edd-repeatable-row-header edd-draghandle-anchor">
 		<span class="edd-repeatable-row-title" title="<?php _e( 'Click and drag to re-order files', 'easy-digital-downloads' ); ?>">
 			<?php printf( esc_html__( '%1$s file ID: %2$s', 'easy-digital-downloads' ), esc_html( edd_get_label_singular() ), '<span class="edd_file_id">' . esc_html( $key ) . '</span>' ); ?>
 			<input type="hidden" name="edd_download_files[<?php echo esc_attr( $key ); ?>][index]" class="edd_repeatable_index" value="<?php echo esc_attr( $index ); ?>"/>
 		</span>
+		<?php
+		$actions = array();
+		if ( $custom_file_options ) {
+			$actions['show_advanced'] = '<a href="#" class="toggle-custom-price-option-section">' . __( 'Show advanced settings', 'easy-digital-downloads' ) . '</a>';
+		}
+
+		$actions['remove'] = '<a class="edd-remove-row edd-delete" data-type="file">' . esc_html__( 'Remove', 'easy-digital-downloads' ) . '<span class="screen-reader-text">' . sprintf( __( 'Remove file %s', 'easy-digital-downloads' ), esc_html( $key ) ) . '</span></a>';
+		?>
 		<span class="edd-repeatable-row-actions">
-			<a class="edd-remove-row edd-delete" data-type="file">
-				<?php esc_html_e( 'Remove', 'easy-digital-downloads' ); ?><span class="screen-reader-text"><?php printf( esc_html__( 'Remove file %s', 'easy-digital-downloads' ), esc_html( $key ) ); ?></span>
-			</a>
+			<?php echo implode( '&nbsp;&#124;&nbsp;', $actions ); ?>
 		</span>
 	</div>
 
@@ -887,7 +898,21 @@ function edd_render_file_row( $key, $args, $post_id, $index ) {
 		<?php do_action( 'edd_download_file_table_row', $post_id, $key, $args ); ?>
 
 	</div>
-<?php
+
+	<?php
+	if ( $custom_file_options ) {
+		?>
+
+		<div class="edd-custom-price-option-sections-wrap">
+			<div class="edd-custom-price-option-sections">
+				<?php
+					do_action( 'edd_download_file_option_row', $post_id, $key, $args );
+				?>
+			</div>
+		</div>
+
+		<?php
+	}
 }
 add_action( 'edd_render_file_row', 'edd_render_file_row', 10, 4 );
 


### PR DESCRIPTION
Fixes #9261

Added supported for "advanced settings" in the file metabox row. This was needed as I need to allow the ability to add settings on a per file basis and the row option wasn't a good option from a UX perspective.

See an example of it working here:

<img width="1373" alt="Screenshot 2022-11-17 at 01 53 23" src="https://user-images.githubusercontent.com/22668877/202312007-f951233e-886d-41a8-86c4-c15086a09aa5.png">

_Please do not submit PRs with minified CSS or JS files. This is managed at the time of release by the Core Team_
