### PR TITLE
Update receipt link email tag rendering

### DIFF
--- a/includes/emails/template.php
+++ b/includes/emails/template.php
@@ -259,12 +259,38 @@ function edd_render_receipt_in_browser( $data ) {
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title><?php _e( 'Receipt', 'easy-digital-downloads' ); ?></title>
+		<title><?php esc_html_e( 'Receipt', 'easy-digital-downloads' ); ?></title>
 		<meta charset="utf-8" />
 		<meta name="robots" content="noindex, nofollow" />
 		<?php wp_head(); ?>
+		<style>
+			body.edd_receipt_page {
+				margin: 12px auto;
+				align-items: center;
+				border: 1px solid #cfcfcf;
+				max-width: fit-content;
+				padding: 12px 24px;
+				border-radius: 8px;
+			}
+
+			.edd_receipt_page #edd_login_form fieldset {
+				border: none;
+				display: grid;
+			}
+
+			.edd_receipt_page #edd_login_form label,
+			.edd_receipt_page #edd_login_form input[type=text],
+			.edd_receipt_page #edd_login_form input[type=password]{
+				display: block;
+				width: 100%;
+			}
+
+			.edd_receipt_page th {
+				text-align: left;
+			}
+		</style>
 	</head>
-<body class="<?php echo apply_filters('edd_receipt_page_body_class', 'edd_receipt_page' ); ?>">
+<body class="<?php echo esc_attr( apply_filters( 'edd_receipt_page_body_class', 'edd_receipt_page' ) ); ?>">
 	<div id="edd_receipt_wrapper">
 		<?php do_action( 'edd_render_receipt_in_browser_before' ); ?>
 		<?php echo do_shortcode( '[edd_receipt payment_key=' . $key . ']' ); ?>

--- a/includes/emails/template.php
+++ b/includes/emails/template.php
@@ -234,13 +234,25 @@ function edd_get_sale_notification_body_content( $payment_id = 0, $payment_data 
  *
  * @since 1.5
  * @author Sunny Ratilal
+ * @param array $data The request data.
  */
-function edd_render_receipt_in_browser() {
-	if ( ! isset( $_GET['payment_key'] ) ) {
+function edd_render_receipt_in_browser( $data ) {
+	if ( ! isset( $data['payment_key'] ) ) {
 		wp_die( __( 'Missing purchase key.', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ) );
 	}
 
-	$key = urlencode( $_GET['payment_key'] );
+	if ( ! empty( $_POST['edd_action'] ) && ! empty( $_POST['edd_user_login'] ) && ! empty( $_POST['edd_login_nonce'] ) ) {
+		return;
+	}
+
+	$key = urlencode( $data['payment_key'] );
+	$url = add_query_arg(
+		array(
+			'payment_key' => $key,
+			'edd_action'  => 'view_receipt',
+		),
+		home_url()
+	);
 
 	ob_start();
 
@@ -262,7 +274,7 @@ function edd_render_receipt_in_browser() {
 <body class="<?php echo apply_filters('edd_receipt_page_body_class', 'edd_receipt_page' ); ?>">
 	<div id="edd_receipt_wrapper">
 		<?php do_action( 'edd_render_receipt_in_browser_before' ); ?>
-		<?php echo do_shortcode('[edd_receipt payment_key='. $key .']'); ?>
+		<?php echo do_shortcode( '[edd_receipt payment_key='. $key . ' redirect=' . esc_url_raw( $url ) . ']' ); ?>
 		<?php do_action( 'edd_render_receipt_in_browser_after' ); ?>
 	</div>
 <?php wp_footer(); ?>

--- a/includes/emails/template.php
+++ b/includes/emails/template.php
@@ -246,13 +246,6 @@ function edd_render_receipt_in_browser( $data ) {
 	}
 
 	$key = urlencode( $data['payment_key'] );
-	$url = add_query_arg(
-		array(
-			'payment_key' => $key,
-			'edd_action'  => 'view_receipt',
-		),
-		home_url()
-	);
 
 	ob_start();
 
@@ -274,7 +267,7 @@ function edd_render_receipt_in_browser( $data ) {
 <body class="<?php echo apply_filters('edd_receipt_page_body_class', 'edd_receipt_page' ); ?>">
 	<div id="edd_receipt_wrapper">
 		<?php do_action( 'edd_render_receipt_in_browser_before' ); ?>
-		<?php echo do_shortcode( '[edd_receipt payment_key='. $key . ' redirect=' . esc_url_raw( $url ) . ']' ); ?>
+		<?php echo do_shortcode( '[edd_receipt payment_key=' . $key . ']' ); ?>
 		<?php do_action( 'edd_render_receipt_in_browser_after' ); ?>
 	</div>
 <?php wp_footer(); ?>

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -673,7 +673,6 @@ function edd_receipt_shortcode( $atts, $content = null ) {
 		'payment_key'    => false,
 		'payment_method' => true,
 		'payment_id'     => true,
-		'redirect'       => edd_get_current_page_url(),
 	), $atts, 'edd_receipt' );
 
 	$session = edd_get_purchase_session();
@@ -699,7 +698,7 @@ function edd_receipt_shortcode( $atts, $content = null ) {
 	// Key was provided, but user is logged out. Offer them the ability to login and view the receipt
 	if ( ! $user_can_view && ! empty( $payment_key ) && ! is_user_logged_in() && ! edd_is_guest_payment( $order->id ) ) {
 		global $edd_login_redirect;
-		$edd_login_redirect = $edd_receipt_args['redirect'];
+		$edd_login_redirect = edd_get_receipt_page_uri( $order->id );
 
 		ob_start();
 

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -664,15 +664,16 @@ function edd_receipt_shortcode( $atts, $content = null ) {
 	global $edd_receipt_args;
 
 	$edd_receipt_args = shortcode_atts( array(
-		'error'           => __( 'Sorry, trouble retrieving order receipt.', 'easy-digital-downloads' ),
-		'price'           => true,
-		'discount'        => true,
-		'products'        => true,
-		'date'            => true,
-		'notes'           => true,
-		'payment_key'     => false,
-		'payment_method'  => true,
-		'payment_id'      => true
+		'error'          => __( 'Sorry, trouble retrieving order receipt.', 'easy-digital-downloads' ),
+		'price'          => true,
+		'discount'       => true,
+		'products'       => true,
+		'date'           => true,
+		'notes'          => true,
+		'payment_key'    => false,
+		'payment_method' => true,
+		'payment_id'     => true,
+		'redirect'       => edd_get_current_page_url(),
 	), $atts, 'edd_receipt' );
 
 	$session = edd_get_purchase_session();
@@ -698,7 +699,7 @@ function edd_receipt_shortcode( $atts, $content = null ) {
 	// Key was provided, but user is logged out. Offer them the ability to login and view the receipt
 	if ( ! $user_can_view && ! empty( $payment_key ) && ! is_user_logged_in() && ! edd_is_guest_payment( $order->id ) ) {
 		global $edd_login_redirect;
-		$edd_login_redirect = edd_get_current_page_url();
+		$edd_login_redirect = $edd_receipt_args['redirect'];
 
 		ob_start();
 


### PR DESCRIPTION
Fixes #9414

Proposed Changes:
1. Updates the `edd_receipt_shortcode` parameters to include a redirect attribute, set to the `edd_get_current_page_url()` by default.
2. Updates `edd_render_receipt_in_browser()`:
    * To use the `$data` parameter provided by the EDD hook.
    * To return early if the login submission is detected so that the `edd_post_actions` will take precedence instead.
    * To add the payment ID/EDD action to a URL to add to the shortcode as a custom redirect since this is not part of the `$wp->request`.