### PR TITLE
Update early return in edd_build_order

### DIFF
--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -649,13 +649,6 @@ function edd_build_order( $order_data = array() ) {
 		return false;
 	}
 
-	$order_data = wp_parse_args(
-		$order_data,
-		array(
-			'user_info' => array(),
-		)
-	);
-
 	/* Order recovery ********************************************************/
 
 	$resume_order   = false;

--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -656,10 +656,6 @@ function edd_build_order( $order_data = array() ) {
 		)
 	);
 
-	if ( empty( $order_data['user_info']['email'] ) ) {
-		return false;
-	}
-
 	/* Order recovery ********************************************************/
 
 	$resume_order   = false;
@@ -815,6 +811,11 @@ function edd_build_order( $order_data = array() ) {
 		edd_update_order( $order_id, $order_args );
 	} else {
 		$order_id = edd_add_order( $order_args );
+	}
+
+	// If there is no order ID at this point, something went wrong.
+	if ( empty( $order_id ) ) {
+		return false;
 	}
 
 	// Attach order to the customer record.

--- a/tests/orders/tests-edd-payment.php
+++ b/tests/orders/tests-edd-payment.php
@@ -972,21 +972,6 @@ class EDD_Payment_Tests extends \EDD_UnitTestCase {
 		$this->assertEquals( 'complete', $order_item->status );
 	}
 
-	public function test_inserting_payment_invalid_data_returns_false() {
-		$payment = edd_insert_payment(
-			array(
-				'customer_id' => 1,
-				'email'       => 'admin@edd.local',
-				'user_id'     => 1,
-				'gateway'     => 'manual',
-				'total'       => edd_sanitize_amount( sanitize_text_field( 20 ) ),
-				'status'      => 'pending',
-			)
-		);
-
-		$this->assertFalse( $payment );
-	}
-
 	public function test_inserting_payment_incomplete_data_returns_true() {
 		$payment = edd_insert_payment(
 			array(


### PR DESCRIPTION
Fixes #9570

Proposed Changes:
1. Removes the user info/email check from `edd_build_order`.
2. Adds an early return if no order ID was found or the order was not successfully added.