### PR TITLE
Return a float where promised for function edd_get_payment_amount

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1249,7 +1249,7 @@ function edd_get_payment_amount( $order_id = 0 ) {
 
 	// Bail if nothing was passed.
 	if ( empty( $order_id ) ) {
-		return '';
+		return 0.00;
 	}
 
 	$order = edd_get_order( $order_id );


### PR DESCRIPTION
- Doc block indicates float should be returned
- If order_id param is empty, function returns an empty string
- fix replaces empty string with zeroed out float value (0.00)

Fixes #9603 

Proposed Changes:
1. replace empty string with zeroed out float value (0.00) to uphold documentation and offer more consistency
