### PR TITLE
Better structured data filters

### DIFF
--- a/includes/class-structured-data.php
+++ b/includes/class-structured-data.php
@@ -165,34 +165,43 @@ class Structured_Data {
 			$offers = array();
 
 			foreach ( $variable_prices as $price ) {
-				$offers[] = array(
-					'@type'           => 'Offer',
-					'price'           => $price['amount'],
-					'priceCurrency'   => edd_get_currency(),
-					'priceValidUntil' => date( 'c', time() + YEAR_IN_SECONDS ),
-					'itemOffered'     => $data['name'] . ' - ' . $price['name'],
-					'url'             => $data['url'],
-					'availability'    => 'http://schema.org/InStock',
-					'seller'          => array(
-						'@type' => 'Organization',
-						'name'  => get_bloginfo( 'name' ),
+				$offers[] = apply_filters(
+					'edd_generate_download_structured_data_variable_price_offer',
+					array(
+						'@type'           => 'Offer',
+						'price'           => $price['amount'],
+						'priceCurrency'   => edd_get_currency(),
+						'priceValidUntil' => date( 'c', time() + YEAR_IN_SECONDS ),
+						'itemOffered'     => $data['name'] . ' - ' . $price['name'],
+						'url'             => $data['url'],
+						'availability'    => 'http://schema.org/InStock',
+						'seller'          => array(
+							'@type' => 'Organization',
+							'name'  => get_bloginfo( 'name' ),
+						),
 					),
+					$download,
+					$price
 				);
 			}
 
 			$data['offers'] = $offers;
 		} else {
-			$data['offers'] = array(
-				'@type'           => 'Offer',
-				'price'           => $download->get_price(),
-				'priceCurrency'   => edd_get_currency(),
-				'priceValidUntil' => null,
-				'url'             => $data['url'],
-				'availability'    => 'http://schema.org/InStock',
-				'seller'          => array(
-					'@type' => 'Organization',
-					'name'  => get_bloginfo( 'name' ),
+			$data['offers'] = apply_filters(
+				'edd_generate_download_structured_data_offer',
+				array(
+					'@type'           => 'Offer',
+					'price'           => $download->get_price(),
+					'priceCurrency'   => edd_get_currency(),
+					'priceValidUntil' => null,
+					'url'             => $data['url'],
+					'availability'    => 'http://schema.org/InStock',
+					'seller'          => array(
+						'@type' => 'Organization',
+						'name'  => get_bloginfo( 'name' ),
+					)
 				),
+				$download
 			);
 		}
 

--- a/includes/class-structured-data.php
+++ b/includes/class-structured-data.php
@@ -139,7 +139,7 @@ class Structured_Data {
 			'name'        => $download->post_title,
 			'url'         => get_permalink( $download->ID ),
 			'brand'       => array(
-				'@type' => 'Thing',
+				'@type' => 'http://schema.org/Brand',
 				'name'  => get_bloginfo( 'name' ),
 			),
 			'sku'         => '-' === $download->get_sku()

--- a/includes/class-structured-data.php
+++ b/includes/class-structured-data.php
@@ -218,7 +218,7 @@ class Structured_Data {
 		 *
 		 * @param array $data Structured data for a download.
 		 */
-		$data = apply_filters( 'edd_generate_download_structured_data', $data );
+		$data = apply_filters( 'edd_generate_download_structured_data', $data, $download );
 
 		$this->set_data( $data );
 


### PR DESCRIPTION
This PR modifies the class responsible for producing LD+JSON structured data as follows
1. Corrects the schema type of the brand attribute from `Thing` to `Brand` as `Thing` is invalid 
2. Introduces two new filters (`edd_generate_download_structured_data_variable_price_offer` / `edd_generate_download_structured_data_offer`) for the Offer elements of the structured data that pass the `EDD_Download` being processed as well as the specific `price` being processed for variable priced items
3. Passes the `EDD_Download` being processed to the `edd_generate_download_structured_data` filter so that filters know which download is being processed without having to guess from the calculated SKU and potentially re-load the `EDD_Download` instance
