### PR TITLE
Adding EDD 3.1.0.6

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,6 +8,6 @@ Support Ticket
 
 We recommend all users with support questions email us via the support form found at [easydigitaldownloads.com/support/](https://easydigitaldownloads.com/support/). GitHub is used for core development only, and is not the place to seek help or report non-developer issues for Easy Digital Downloads, or EDD addons or themes.
 
-Before opening a support ticket, please also review our [documentation](http://docs.easydigitaldownloads.com) for assistance with common issues and FAQs.
+Before opening a support ticket, please also review our [documentation](https://easydigitaldownloads.com/docs) for assistance with common issues and FAQs.
 
 If reporting a bug, please be as descriptive as possible and include links to screenshots or screenshares that demonstrate the issue.

--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -5,7 +5,7 @@
  * Description: The easiest way to sell digital products with WordPress.
  * Author: Easy Digital Downloads
  * Author URI: https://easydigitaldownloads.com
- * Version: 3.1.0.5
+ * Version: 3.1.0.6
  * Text Domain: easy-digital-downloads
  * Domain Path: languages
  * Requires PHP: 5.6

--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -274,7 +274,7 @@ class EDD_Notices {
 				'is_dismissible' => false,
 				'message'        => array(
 					sprintf( __( 'The files in %s are not currently protected.', 'easy-digital-downloads' ), '<code>' . $upload_directory . '</code>' ),
-					__( 'To protect them, you must add this <a href="https://docs.easydigitaldownloads.com/article/682-protected-download-files-on-nginx">NGINX redirect rule</a>.', 'easy-digital-downloads' ),
+					__( 'To protect them, you must add this <a href="https://easydigitaldownloads.com/docs/download-files-not-protected-on-nginx/">NGINX redirect rule</a>.', 'easy-digital-downloads' ),
 					sprintf( __( 'If you have already done this, or it does not apply to your site, you may permenently %s.', 'easy-digital-downloads' ), '<a href="' . esc_url( $dismiss_notice_url ) . '">' . __( 'dismiss this notice', 'easy-digital-downloads' ) . '</a>' )
 				)
 			) );

--- a/includes/admin/downloads/contextual-help.php
+++ b/includes/admin/downloads/contextual-help.php
@@ -96,9 +96,9 @@ function edd_downloads_contextual_help() {
 	);
 
 	$screen->add_help_tab( array(
-		'id'	    => 'edd-purchase-shortcode',
-		'title'	    => __( 'Purchase Shortcode', 'easy-digital-downloads' ),
-		'content'	=>
+		'id'      => 'edd-purchase-shortcode',
+		'title'   => __( 'Purchase Shortcode', 'easy-digital-downloads' ),
+		'content' =>
 			'<p>' . __( '<strong>Purchase Shortcode</strong> - If the automatic output of the purchase button has been disabled via the Download Configuration box, a shortcode can be used to output the button or link.', 'easy-digital-downloads' ) . '</p>' .
 			'<p><code>[purchase_link id="#" price="1" text="Add to Cart" color="blue"]</code></p>' .
 			'<ul>
@@ -109,7 +109,11 @@ function edd_downloads_contextual_help() {
 				<li><strong>color</strong> - <em>' . implode( '</em> | <em>', $colors ) . '</em></li>
 				<li><strong>class</strong> - ' . __( 'One or more custom CSS classes you want applied to the button.', 'easy-digital-downloads' ) . '</li>
 			</ul>' .
-			'<p>' . sprintf( __( 'For more information, see <a href="%s">using Shortcodes</a> on the WordPress.org Codex or <a href="%s">Easy Digital Downloads Documentation</a>', 'easy-digital-downloads' ), 'https://codex.wordpress.org/Shortcode', 'https://docs.easydigitaldownloads.com/article/229-purchaselink' ) . '</p>'
+			'<p>' . sprintf(
+				__( 'For more information, see <a href="%s">using Shortcodes</a> on the WordPress.org Codex or <a href="%s">Easy Digital Downloads Documentation</a>', 'easy-digital-downloads' ),
+				'https://codex.wordpress.org/Shortcode',
+				'https://easydigitaldownloads.com/docs/purchase_link-shortcode/'
+			) . '</p>'
 	) );
 
 	/**

--- a/includes/admin/reporting/export/class-batch-export-payments.php
+++ b/includes/admin/reporting/export/class-batch-export-payments.php
@@ -91,21 +91,21 @@ class EDD_Batch_Payments_Export extends EDD_Batch_Export {
 		$data = array();
 
 		$args = array(
-			'number'         => 30,
-			'offset'         => ( $this->step * 30 ) - 30,
-			'status'         => $this->status,
-			'order'          => 'ASC',
-			'orderby'        => 'date_created',
-			'type'           => 'sale',
-			'status__not_in' => array( 'trash' ),
+			'number'  => 30,
+			'offset'  => ( $this->step * 30 ) - 30,
+			'status'  => $this->status,
+			'order'   => 'ASC',
+			'orderby' => 'date_created',
+			'type'    => 'sale',
 		);
 
 		if ( ! empty( $this->start ) || ! empty( $this->end ) ) {
 			$args['date_query'] = $this->get_date_query();
 		}
 
-		if ( 'all' === $args['status'] ) {
+		if ( in_array( $args['status'], array( 'any', 'all' ), true ) ) {
 			unset( $args['status'] );
+			$args['status__not_in'] = array( 'trash' );
 		}
 
 		$orders = edd_get_orders( $args );
@@ -241,14 +241,15 @@ class EDD_Batch_Payments_Export extends EDD_Batch_Export {
 	public function get_percentage_complete() {
 		$args = array(
 			'fields' => 'ids',
+			'status' => $this->status,
 		);
 
 		if ( ! empty( $this->start ) || ! empty( $this->end ) ) {
 			$args['date_query'] = $this->get_date_query();
 		}
 
-		if ( 'any' !== $this->status ) {
-			$args['status'] = $this->status;
+		if ( in_array( $args['status'], array( 'any', 'all' ), true ) ) {
+			unset( $args['status'] );
 		}
 
 		$total = edd_count_orders( $args );

--- a/includes/admin/reporting/export/class-batch-export-taxed-orders.php
+++ b/includes/admin/reporting/export/class-batch-export-taxed-orders.php
@@ -90,20 +90,20 @@ class EDD_Batch_Taxed_Orders_Export extends EDD_Batch_Export {
 		$data = array();
 
 		$args = array(
-			'number'         => 30,
-			'offset'         => ( $this->step * 30 ) - 30,
-			'status'         => $this->status,
-			'order'          => 'ASC',
-			'orderby'        => 'date_created',
-			'status__not_in' => array( 'trash' ),
+			'number'  => 30,
+			'offset'  => ( $this->step * 30 ) - 30,
+			'status'  => $this->status,
+			'order'   => 'ASC',
+			'orderby' => 'date_created',
 		);
 
 		if ( ! empty( $this->start ) || ! empty( $this->end ) ) {
 			$args['date_created_query'] = $this->get_date_query();
 		}
 
-		if ( 'any' === $args['status'] || 'all' === $args['status'] ) {
+		if ( in_array( $args['status'], array( 'any', 'all' ), true ) ) {
 			unset( $args['status'] );
+			$args['status__not_in'] = array( 'trash' );
 		}
 
 		add_filter( 'edd_orders_query_clauses', array( $this, 'query_clauses' ), 10, 2 );
@@ -236,14 +236,15 @@ class EDD_Batch_Taxed_Orders_Export extends EDD_Batch_Export {
 	public function get_percentage_complete() {
 		$args = array(
 			'fields' => 'ids',
+			'status' => $this->status,
 		);
 
 		if ( ! empty( $this->start ) || ! empty( $this->end ) ) {
 			$args['date_created_query'] = $this->get_date_query();
 		}
 
-		if ( 'any' !== $this->status ) {
-			$args['status'] = $this->status;
+		if ( in_array( $args['status'], array( 'any', 'all' ), true ) ) {
+			unset( $args['status'] );
 		}
 
 		$total      = edd_count_orders( $args );

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -924,7 +924,7 @@ function edd_get_registered_settings() {
 					'tax_help' => array(
 						'id'   => 'tax_help',
 						'name' => '',
-						'desc' => sprintf( __( 'Visit the <a href="%s" target="_blank">Tax setup documentation</a> for further information. <p class="description">If you need VAT support, there are options listed on the documentation page.</p>', 'easy-digital-downloads' ), 'https://docs.easydigitaldownloads.com/article/238-tax-settings' ),
+						'desc' => sprintf( __( 'Visit the <a href="%s" target="_blank">Tax setup documentation</a> for further information. <p class="description">If you need VAT support, there are options listed on the documentation page.</p>', 'easy-digital-downloads' ), 'https://easydigitaldownloads.com/docs/tax-settings/' ),
 						'type' => 'descriptive_text',
 					),
 					'prices_include_tax' => array(
@@ -1837,9 +1837,9 @@ function edd_get_registered_settings_sections() {
  */
 function edd_get_pages( $force = false ) {
 
-	$pages_options = array( '' => '' ); // Blank option
+	$pages_options = array( '' => __( 'None', 'easy-digital-downloads' ) );
 
-	if ( ( ! isset( $_GET['page'] ) || 'edd-settings' != $_GET['page'] ) && ! $force ) {
+	if ( ( ! isset( $_GET['page'] ) || 'edd-settings' !== $_GET['page'] ) && ! $force ) {
 		return $pages_options;
 	}
 

--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -484,7 +484,7 @@ function edd_tools_import_export_display() {
 						<?php
 						printf(
 							__( 'Each column loaded from the CSV needs to be mapped to an order field. Select the column that should be mapped to each field below. Any columns not needed can be ignored. See <a href="%s" target="_blank">this guide</a> for assistance with importing payment records.', 'easy-digital-downloads' ),
-							'https://docs.easydigitaldownloads.com/category/1337-importexport'
+							'https://easydigitaldownloads.com/docs/importing-exporting-orders/'
 						);
 						?>
 					</p>
@@ -799,7 +799,7 @@ function edd_tools_import_export_display() {
 						<?php
 						printf(
 							__( 'Each column loaded from the CSV needs to be mapped to a Download product field. Select the column that should be mapped to each field below. Any columns not needed can be ignored. See <a href="%s" target="_blank">this guide</a> for assistance with importing Download products.', 'easy-digital-downloads' ),
-							'https://docs.easydigitaldownloads.com/category/1337-importexport'
+							'https://easydigitaldownloads.com/docs/importing-exporting-products/'
 						);
 						?>
 					</p>

--- a/includes/class-easy-digital-downloads.php
+++ b/includes/class-easy-digital-downloads.php
@@ -325,7 +325,7 @@ final class Easy_Digital_Downloads {
 
 		// Plugin version.
 		if ( ! defined( 'EDD_VERSION' ) ) {
-			define( 'EDD_VERSION', '3.1.0.5' );
+			define( 'EDD_VERSION', '3.1.0.6' );
 		}
 
 		// Plugin Root File.

--- a/includes/database/README.md
+++ b/includes/database/README.md
@@ -381,6 +381,4 @@ This table's data is intended to be immutable. However, some column data is also
 | total | This is the total amount of the order. |
 | date_created | The date this row was created. |
 | date_modified | The date this row was last modified. |
-| date_completed | The date the order was marked as completed by the gateway. |
-| date_refundable | The date after which that the order can no longer be reunded. |
 | uuid | A unique identifying string representing this row. |

--- a/includes/gateways/paypal-standard.php
+++ b/includes/gateways/paypal-standard.php
@@ -71,7 +71,7 @@ function edd_register_paypal_gateway_settings( $gateway_settings ) {
 
 	$pdt_desc = sprintf(
 		__( 'Enter your PayPal Identity Token in order to enable Payment Data Transfer (PDT). This allows payments to be verified without relying on the PayPal IPN. See our <a href="%s" target="_blank">documentation</a> for further information.', 'easy-digital-downloads' ),
-		'https://docs.easydigitaldownloads.com/article/918-paypal-standard'
+		'https://easydigitaldownloads.com/docs/paypal-legacy-gateways-standard-express-pro-advanced/'
 	);
 
 	$paypal_settings['paypal_identify_token'] = array(
@@ -84,7 +84,7 @@ function edd_register_paypal_gateway_settings( $gateway_settings ) {
 
 	$desc  = sprintf(
 		__( 'If you are unable to use Payment Data Transfer and payments are not getting marked as complete, then check this box. This forces the site to use a slightly less secure method of verifying purchases. See our <a href="%s" target="_blank">FAQ</a> for further information.', 'easy-digital-downloads' ),
-		'https://docs.easydigitaldownloads.com/article/190-payments-not-marked-as-complete'
+		'https://easydigitaldownloads.com/docs/paypal-payments-not-marked-as-complete/'
 	);
 
 	$paypal_settings['disable_paypal_verification'] = array(

--- a/includes/gateways/paypal/admin/connect.php
+++ b/includes/gateways/paypal/admin/connect.php
@@ -114,7 +114,8 @@ function process_connect() {
 			'country_code'  => edd_get_shop_country(),
 			'currency_code' => edd_get_currency(),
 			'return_url'    => get_settings_url()
-		) )
+		) ),
+		'user-agent' => 'Easy Digital Downloads/' . EDD_VERSION . '; ' . get_bloginfo( 'name' ),
 	) );
 
 	if ( is_wp_error( $response ) ) {
@@ -245,7 +246,8 @@ function get_and_save_credentials() {
 			'grant_type'    => 'authorization_code',
 			'code'          => $_POST['auth_code'],
 			'code_verifier' => $partner_details->nonce
-		)
+		),
+		'user-agent' => 'Easy Digital Downloads/' . EDD_VERSION . '; ' . get_bloginfo( 'name' ),
 	) );
 
 	if ( is_wp_error( $response ) ) {
@@ -272,7 +274,8 @@ function get_and_save_credentials() {
 			'Authorization' => sprintf( 'Bearer %s', $body->access_token ),
 			'Content-Type'  => 'application/json',
 			'timeout'       => 15
-		)
+		),
+		'user-agent' => 'Easy Digital Downloads/' . EDD_VERSION . '; ' . get_bloginfo( 'name' ),
 	) );
 
 	if ( is_wp_error( $response ) ) {
@@ -748,7 +751,8 @@ function get_merchant_status( $merchant_id, $nonce = '' ) {
 			'mode'        => edd_is_test_mode() ? API::MODE_SANDBOX : API::MODE_LIVE,
 			'merchant_id' => $merchant_id,
 			'nonce'       => $nonce
-		) )
+		) ),
+		'user-agent' => 'Easy Digital Downloads/' . EDD_VERSION . '; ' . get_bloginfo( 'name' ),
 	) );
 
 	$response_code = wp_remote_retrieve_response_code( $response );

--- a/includes/gateways/paypal/admin/notices.php
+++ b/includes/gateways/paypal/admin/notices.php
@@ -52,7 +52,7 @@ add_action( 'admin_notices', function () {
 			echo wp_kses( sprintf(
 				/* Translators: %1$s opening anchor tag; %2$s closing anchor tag */
 				__( 'A new, improved PayPal experience is now available in Easy Digital Downloads. You can learn more about the new integration in %1$sour documentation%2$s.', 'easy-digital-downloads' ),
-				'<a href="https://docs.easydigitaldownloads.com/article/2410-paypal#migration" target="_blank">',
+				'<a href="https://easydigitaldownloads.com/docs/paypal-setup/#upgrade" target="_blank">',
 				'</a>'
 			), array( 'a' => array( 'href' => true, 'target' => true ) ) );
 			?>

--- a/includes/gateways/paypal/admin/settings.php
+++ b/includes/gateways/paypal/admin/settings.php
@@ -135,7 +135,7 @@ function documentation_settings_field() {
 		<?php
 		echo wp_kses( sprintf(
 			__( 'To learn more about the PayPal gateway, visit <a href="%s" target="_blank">our documentation</a>.', 'easy-digital-downloads' ),
-			'https://docs.easydigitaldownloads.com/article/2410-paypal'
+			'https://easydigitaldownloads.com/docs/paypal-setup/'
 		), array( 'a' => array( 'href' => true, 'target' => true ) ) )
 		?>
 	</p>
@@ -147,7 +147,7 @@ function documentation_settings_field() {
 				<?php
 				echo wp_kses( sprintf(
 					__( 'PayPal requires an SSL certificate to accept payments. You can learn more about obtaining an SSL certificate in our <a href="%s" target="_blank">SSL setup article</a>.', 'easy-digital-downloads' ),
-					'https://docs.easydigitaldownloads.com/article/994-how-to-set-up-ssl'
+					'https://easydigitaldownloads.com/docs/do-i-need-an-ssl-certificate/'
 				), array( 'a' => array( 'href' => true, 'target' => true ) ) );
 				?>
 			</p>

--- a/includes/gateways/paypal/class-paypal-api.php
+++ b/includes/gateways/paypal/class-paypal-api.php
@@ -194,7 +194,8 @@ class API {
 			),
 			'body'    => array(
 				'grant_type' => 'client_credentials'
-			)
+			),
+			'user-agent' => 'Easy Digital Downloads/' . EDD_VERSION . '; ' . get_bloginfo( 'name' ),
 		) );
 
 		$body = json_decode( wp_remote_retrieve_body( $response ) );

--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -731,11 +731,11 @@ function edd_purchase_form_validate_user_login() {
 
 	// Start an array to collect valid user data.
 	$valid_user_data = array(
-		'user_id' => 0
+		'user_id' => 0,
 	);
 
 	$user_login = ! empty( $_POST['edd_user_login'] ) ? sanitize_text_field( $_POST['edd_user_login'] ) : '';
-	$user_pass  = ! empty( $_POST['edd_user_pass'] ) ? sanitize_text_field( $_POST['edd_user_pass'] ) : '';
+	$user_pass  = ! empty( $_POST['edd_user_pass'] ) ? $_POST['edd_user_pass'] : '';
 
 	// Username.
 	if ( empty( $user_login ) && edd_no_guest_checkout() ) {
@@ -747,19 +747,17 @@ function edd_purchase_form_validate_user_login() {
 
 	if ( ! $user instanceof WP_User ) {
 		return $valid_user_data;
-	} else {
-		// Re-populate the valid user data array.
-		$valid_user_data = array(
-			'user_id' => $user->ID,
-			'user_login' => $user->user_login,
-			'user_email' => $user->user_email,
-			'user_first' => $user->first_name,
-			'user_last' => $user->last_name,
-			'user_pass' => $user_pass,
-		);
 	}
 
-	return (array) $valid_user_data;
+	// Populate the valid user data array.
+	return array(
+		'user_id'    => $user->ID,
+		'user_login' => $user->user_login,
+		'user_email' => $user->user_email,
+		'user_first' => $user->first_name,
+		'user_last'  => $user->last_name,
+		'user_pass'  => $user_pass,
+	);
 }
 
 /**

--- a/includes/users/login.php
+++ b/includes/users/login.php
@@ -165,6 +165,15 @@ function edd_update_login_url( $url, $redirect_to, $force_reauth ) {
 		return $url;
 	}
 
+	/**
+	 * If the $wp_rewrite global hasn't been initialized, don't do anything.
+	 * This is added defensively for situations where `wp_login_url` may be called too early.
+	 */
+	global $wp_rewrite;
+	if ( ! $wp_rewrite ) {
+		return $url;
+	}
+
 	// Get the login page URL and return the default if it's not set.
 	$login_url = edd_get_login_page_uri();
 	if ( ! $login_url ) {
@@ -188,6 +197,9 @@ function edd_update_login_url( $url, $redirect_to, $force_reauth ) {
  */
 function edd_get_login_page_uri() {
 	$login_page = edd_get_option( 'login_page', false );
+	if ( ! function_exists( 'has_block' ) || ( $login_page && ! has_block( 'edd/login', absint( $login_page ) ) ) ) {
+		return false;
+	}
 
 	return $login_page ? get_permalink( $login_page ) : false;
 }

--- a/languages/easy-digital-downloads.pot
+++ b/languages/easy-digital-downloads.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the same license as the Easy Digital Downloads plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Digital Downloads 3.1.0.4\n"
+"Project-Id-Version: Easy Digital Downloads 3.1.0.6\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/easy-digital-downloads-pro\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-01-25T19:06:48+00:00\n"
+"POT-Creation-Date: 2023-02-09T21:17:35+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.7.1\n"
+"X-Generator: WP-CLI 2.6.0\n"
 "X-Domain: easy-digital-downloads\n"
 
 #. Plugin Name of the plugin
@@ -253,11 +253,11 @@ msgstr ""
 #: includes/gateways/functions.php:320
 #: includes/gateways/manual.php:33
 #: includes/gateways/paypal-standard.php:170
-#: includes/gateways/paypal/admin/connect.php:517
-#: includes/gateways/paypal/admin/connect.php:521
-#: includes/gateways/paypal/admin/connect.php:558
-#: includes/gateways/paypal/admin/connect.php:562
-#: includes/gateways/paypal/admin/connect.php:704
+#: includes/gateways/paypal/admin/connect.php:520
+#: includes/gateways/paypal/admin/connect.php:524
+#: includes/gateways/paypal/admin/connect.php:561
+#: includes/gateways/paypal/admin/connect.php:565
+#: includes/gateways/paypal/admin/connect.php:707
 #: includes/gateways/stripe/includes/admin/upgrade-functions.php:80
 #: includes/gateways/stripe/includes/payment-actions.php:1399
 #: includes/process-download.php:296
@@ -394,7 +394,7 @@ msgid "The files in %s are not currently protected."
 msgstr ""
 
 #: includes/admin/class-edd-notices.php:277
-msgid "To protect them, you must add this <a href=\"https://docs.easydigitaldownloads.com/article/682-protected-download-files-on-nginx\">NGINX redirect rule</a>."
+msgid "To protect them, you must add this <a href=\"https://easydigitaldownloads.com/docs/download-files-not-protected-on-nginx/\">NGINX redirect rule</a>."
 msgstr ""
 
 #: includes/admin/class-edd-notices.php:278
@@ -629,17 +629,17 @@ msgstr ""
 #: includes/admin/tools/class-edd-tools-recount-all-stats.php:78
 #: includes/admin/tools/class-edd-tools-recount-download-stats.php:117
 #: includes/gateways/paypal/admin/connect.php:103
-#: includes/gateways/paypal/admin/connect.php:163
-#: includes/gateways/paypal/admin/connect.php:218
-#: includes/gateways/paypal/admin/connect.php:328
-#: includes/gateways/paypal/admin/connect.php:517
-#: includes/gateways/paypal/admin/connect.php:521
-#: includes/gateways/paypal/admin/connect.php:558
-#: includes/gateways/paypal/admin/connect.php:562
-#: includes/gateways/paypal/admin/connect.php:618
-#: includes/gateways/paypal/admin/connect.php:652
-#: includes/gateways/paypal/admin/connect.php:675
-#: includes/gateways/paypal/admin/connect.php:704
+#: includes/gateways/paypal/admin/connect.php:164
+#: includes/gateways/paypal/admin/connect.php:219
+#: includes/gateways/paypal/admin/connect.php:331
+#: includes/gateways/paypal/admin/connect.php:520
+#: includes/gateways/paypal/admin/connect.php:524
+#: includes/gateways/paypal/admin/connect.php:561
+#: includes/gateways/paypal/admin/connect.php:565
+#: includes/gateways/paypal/admin/connect.php:621
+#: includes/gateways/paypal/admin/connect.php:655
+#: includes/gateways/paypal/admin/connect.php:678
+#: includes/gateways/paypal/admin/connect.php:707
 msgid "You do not have permission to perform this action."
 msgstr ""
 
@@ -1935,7 +1935,7 @@ msgstr ""
 msgid "One or more custom CSS classes you want applied to the button."
 msgstr ""
 
-#: includes/admin/downloads/contextual-help.php:112
+#: includes/admin/downloads/contextual-help.php:113
 msgid "For more information, see <a href=\"%s\">using Shortcodes</a> on the WordPress.org Codex or <a href=\"%s\">Easy Digital Downloads Documentation</a>"
 msgstr ""
 
@@ -4891,6 +4891,7 @@ msgid "Login Form Only"
 msgstr ""
 
 #: includes/admin/settings/register-settings.php:638
+#: includes/admin/settings/register-settings.php:1840
 #: includes/class-edd-discount.php:672
 #: includes/blocks/build/downloads/index.js:1
 #: includes/blocks/build/terms/index.js:1
@@ -9843,8 +9844,8 @@ msgstr ""
 #: includes/gateways/paypal-standard.php:602
 #: includes/gateways/paypal-standard.php:675
 #: includes/gateways/paypal-standard.php:684
-#: includes/gateways/paypal/ipn.php:126
-#: includes/gateways/paypal/ipn.php:134
+#: includes/gateways/paypal/ipn.php:127
+#: includes/gateways/paypal/ipn.php:135
 msgid "IPN Error"
 msgstr ""
 
@@ -10132,12 +10133,12 @@ msgid "PayPal refund failed: %s"
 msgstr ""
 
 #: includes/gateways/paypal/admin/connect.php:32
-#: includes/gateways/paypal/admin/connect.php:357
+#: includes/gateways/paypal/admin/connect.php:360
 msgid "sandbox"
 msgstr ""
 
 #: includes/gateways/paypal/admin/connect.php:32
-#: includes/gateways/paypal/admin/connect.php:357
+#: includes/gateways/paypal/admin/connect.php:360
 msgid "live"
 msgstr ""
 
@@ -10161,103 +10162,103 @@ msgid "Retrieving account information..."
 msgstr ""
 
 #. Translators: %d - HTTP response code; %s - Response from the API
-#: includes/gateways/paypal/admin/connect.php:130
+#: includes/gateways/paypal/admin/connect.php:131
 msgid "Unexpected response code: %d. Error: %s"
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:137
+#: includes/gateways/paypal/admin/connect.php:138
 msgid "An unexpected error occurred."
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:178
+#: includes/gateways/paypal/admin/connect.php:179
 msgid "Failure reconnecting to PayPal. Please try again"
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:184
+#: includes/gateways/paypal/admin/connect.php:185
 msgid "Your account has been successfully reconnected, but an error occurred while creating a webhook."
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:222
+#: includes/gateways/paypal/admin/connect.php:223
 msgid "Missing PayPal authentication information. Please try again."
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:229
+#: includes/gateways/paypal/admin/connect.php:230
 msgid "Missing nonce. Please refresh the page and try again."
 msgstr ""
 
 #. Translators: %d - HTTP response code
-#: includes/gateways/paypal/admin/connect.php:261
+#: includes/gateways/paypal/admin/connect.php:263
 msgid "Unexpected response from PayPal while generating token. Response code: %d. Please try again."
 msgstr ""
 
 #. Translators: %d - HTTP response code
-#: includes/gateways/paypal/admin/connect.php:288
+#: includes/gateways/paypal/admin/connect.php:291
 msgid "Unexpected response from PayPal. Response code: %d. Please try again."
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:296
+#: includes/gateways/paypal/admin/connect.php:299
 msgid "Successfully connected."
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:301
+#: includes/gateways/paypal/admin/connect.php:304
 msgid "Your account has been successfully connected, but an error occurred while creating a webhook."
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:335
+#: includes/gateways/paypal/admin/connect.php:338
 msgid "Re-Check Payment Status"
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:336
+#: includes/gateways/paypal/admin/connect.php:339
 msgid "Sync Webhook"
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:340
+#: includes/gateways/paypal/admin/connect.php:343
 msgid "Disconnect webhooks from PayPal"
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:341
+#: includes/gateways/paypal/admin/connect.php:344
 msgid "Delete connection with PayPal"
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:350
+#: includes/gateways/paypal/admin/connect.php:353
 msgid "API:"
 msgstr ""
 
 #. Translators: %s - the connected mode, either `sandbox` or `live`
-#: includes/gateways/paypal/admin/connect.php:360
+#: includes/gateways/paypal/admin/connect.php:363
 msgid "Your PayPal account is successfully connected in %s mode."
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:375
+#: includes/gateways/paypal/admin/connect.php:378
 msgid "Payment Status:"
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:379
+#: includes/gateways/paypal/admin/connect.php:382
 msgid "You need to address the following issues before you can start receiving payments:"
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:387
+#: includes/gateways/paypal/admin/connect.php:390
 msgid "Ready to accept payments."
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:409
+#: includes/gateways/paypal/admin/connect.php:412
 msgid "Webhook:"
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:417
+#: includes/gateways/paypal/admin/connect.php:420
 msgid "Create Webhooks"
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:422
+#: includes/gateways/paypal/admin/connect.php:425
 msgid "Webhook successfully configured for the following events:"
 msgstr ""
 
 #. Translators: %1$s opening anchor tag; %2$s closing anchor tag; %3$s: opening line item/status/strong tags; %4$s closing strong tag; %5$s: closing list item tag
-#: includes/gateways/paypal/admin/connect.php:447
+#: includes/gateways/paypal/admin/connect.php:450
 msgid "%3$sGateway Status: %4$s PayPal is not currently active. %1$sEnable PayPal%2$s in the general gateway settings to start using it.%5$s"
 msgstr ""
 
-#: includes/gateways/paypal/admin/connect.php:625
+#: includes/gateways/paypal/admin/connect.php:628
 msgid "No merchant ID saved. Please reconnect to PayPal."
 msgstr ""
 
@@ -10438,7 +10439,7 @@ msgid "Missing PayPal credential: %s"
 msgstr ""
 
 #. Translators: %d - HTTP response code.
-#: includes/gateways/paypal/class-paypal-api.php:214
+#: includes/gateways/paypal/class-paypal-api.php:215
 msgid "Unexpected response code: %d"
 msgstr ""
 
@@ -10461,42 +10462,42 @@ msgid "Response Code: %d; Message: %s"
 msgstr ""
 
 #. Translators: %s - IPN Verification response
-#: includes/gateways/paypal/ipn.php:126
-#: includes/gateways/paypal/ipn.php:134
+#: includes/gateways/paypal/ipn.php:127
+#: includes/gateways/paypal/ipn.php:135
 msgid "Invalid PayPal Commerce/Express IPN verification response. IPN data: %s"
 msgstr ""
 
 #. Translators: %s - The payment data sent via the IPN
-#: includes/gateways/paypal/ipn.php:220
+#: includes/gateways/paypal/ipn.php:221
 msgid "Invalid Currency Code"
 msgstr ""
 
 #. Translators: %s - The payment data sent via the IPN
-#: includes/gateways/paypal/ipn.php:220
+#: includes/gateways/paypal/ipn.php:221
 msgid "The currency code in an IPN request did not match the site currency code. Payment data: %s"
 msgstr ""
 
 #. Translators: %s - The transaction ID of the failed payment
-#: includes/gateways/paypal/ipn.php:236
+#: includes/gateways/paypal/ipn.php:237
 msgid "Transaction ID %s failed in PayPal"
 msgstr ""
 
 #. Translators: %s - The collected outstanding balance of the subscription
-#: includes/gateways/paypal/ipn.php:261
+#: includes/gateways/paypal/ipn.php:277
 msgid "Outstanding subscription balance of %s collected successfully."
 msgstr ""
 
-#: includes/gateways/paypal/ipn.php:363
+#: includes/gateways/paypal/ipn.php:379
 #: includes/gateways/paypal/webhooks/events/class-payment-capture-refunded.php:53
 msgid "Amount: %1$s; Payment transaction ID: %2$s; Refund transaction ID: %3$s"
 msgstr ""
 
-#: includes/gateways/paypal/ipn.php:375
+#: includes/gateways/paypal/ipn.php:391
 #: includes/gateways/paypal/webhooks/events/class-payment-capture-refunded.php:64
 msgid "Partial refund processed in PayPal."
 msgstr ""
 
-#: includes/gateways/paypal/ipn.php:385
+#: includes/gateways/paypal/ipn.php:401
 #: includes/gateways/paypal/webhooks/events/class-payment-capture-refunded.php:72
 msgid "Full refund processed in PayPal."
 msgstr ""
@@ -11049,7 +11050,7 @@ msgstr ""
 
 #: includes/gateways/stripe/includes/compat.php:116
 #: includes/process-purchase.php:569
-#: includes/process-purchase.php:942
+#: includes/process-purchase.php:940
 msgid "The user information is invalid"
 msgstr ""
 
@@ -12100,13 +12101,13 @@ msgstr ""
 
 #: includes/privacy-functions.php:27
 msgid ""
-"\n"
-"We collect information about you during the checkout process on our store. This information may include, but is not limited to, your name, billing address, shipping address, email address, phone number, credit card/payment details and any other details that might be requested from you for the purpose of processing your orders.\n"
-"Handling this data also allows us to:\n"
-"- Send you important account/order/service information.\n"
-"- Respond to your queries, refund requests, or complaints.\n"
-"- Process payments and to prevent fraudulent transactions. We do this on the basis of our legitimate business interests.\n"
-"- Set up and administer your account, provide technical and/or customer support, and to verify your identity.\n"
+"\r\n"
+"We collect information about you during the checkout process on our store. This information may include, but is not limited to, your name, billing address, shipping address, email address, phone number, credit card/payment details and any other details that might be requested from you for the purpose of processing your orders.\r\n"
+"Handling this data also allows us to:\r\n"
+"- Send you important account/order/service information.\r\n"
+"- Respond to your queries, refund requests, or complaints.\r\n"
+"- Process payments and to prevent fraudulent transactions. We do this on the basis of our legitimate business interests.\r\n"
+"- Set up and administer your account, provide technical and/or customer support, and to verify your identity.\r\n"
 ""
 msgstr ""
 
@@ -12366,7 +12367,7 @@ msgstr ""
 
 #: includes/process-purchase.php:564
 #: includes/process-purchase.php:674
-#: includes/process-purchase.php:794
+#: includes/process-purchase.php:792
 #: includes/users/register.php:75
 msgid "Invalid email"
 msgstr ""
@@ -12398,7 +12399,7 @@ msgid "Email already used. Login or use a different email to complete your purch
 msgstr ""
 
 #: includes/process-purchase.php:692
-#: includes/process-purchase.php:807
+#: includes/process-purchase.php:805
 msgid "Enter an email"
 msgstr ""
 
@@ -12418,27 +12419,27 @@ msgstr ""
 msgid "You must log in or register to complete your purchase"
 msgstr ""
 
-#: includes/process-purchase.php:781
+#: includes/process-purchase.php:779
 msgid "You must be logged into an account to purchase"
 msgstr ""
 
-#: includes/process-purchase.php:798
+#: includes/process-purchase.php:796
 msgid "You cannot use that email address at this time."
 msgstr ""
 
-#: includes/process-purchase.php:1023
+#: includes/process-purchase.php:1021
 msgid "The zip / postal code you entered for your billing address is invalid"
 msgstr ""
 
-#: includes/process-purchase.php:1275
+#: includes/process-purchase.php:1273
 msgid "An internal error has occurred, please try again or contact support."
 msgstr ""
 
-#: includes/process-purchase.php:1294
+#: includes/process-purchase.php:1292
 msgid "Your email address must be shorter than 100 characters."
 msgstr ""
 
-#: includes/process-purchase.php:1326
+#: includes/process-purchase.php:1324
 msgid "There was an error completing your purchase. Please try again."
 msgstr ""
 
@@ -12893,10 +12894,10 @@ msgstr ""
 
 #: includes/user-functions.php:761
 msgid ""
-"Hello %1$s,\n"
-"\n"
-"\t\tYour account with %2$s needs to be verified before you can access your purchase history. <a href=\"%3$s\">Click here</a> to verify your account.\n"
-"\n"
+"Hello %1$s,\r\n"
+"\r\n"
+"\t\tYour account with %2$s needs to be verified before you can access your purchase history. <a href=\"%3$s\">Click here</a> to verify your account.\r\n"
+"\r\n"
 "\t\tLink missing? Visit the following URL: %3$s"
 msgstr ""
 

--- a/readme.md
+++ b/readme.md
@@ -30,5 +30,5 @@ There are various ways you can contribute:
 
 1. Raise an [Issue](https://github.com/easydigitaldownloads/easy-digital-downloads/issues) on GitHub
 2. Send us a Pull Request with your bug fixes and/or new features
-3. Translate Easy Digital Downloads into [different languages](http://docs.easydigitaldownloads.com/article/1023-translating-easy-digital-downloads)
+3. Translate Easy Digital Downloads into [different languages](https://translate.wordpress.org/projects/wp-plugins/easy-digital-downloads/)
 4. Provide feedback and suggestions on [enhancements](https://github.com/easydigitaldownloads/easy-digital-downloads/issues?direction=desc&labels=Enhancement&page=1&sort=created&state=open)

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: ecommerce, e-commerce, sell, digital store, stripe
 Requires at least: 4.9
 Tested up to: 6.1
 Requires PHP: 5.6
-Stable Tag: 3.1.0.5
+Stable Tag: 3.1.0.6
 License: GNU Version 2 or Any Later Version
 
 Sell your digital products with the ecommerce plugin written for digital creators, by digital creators.
@@ -237,6 +237,16 @@ Yes, through the use of our commercial addon called [Recurring Payments](https:/
 8. Checkout - Default Theme
 
 == Changelog ==
+= 3.1.0.6, February 9, 2023 =
+* Improvement: The PayPal Backup IPN now sends the payment date when handling a renewal from Recurring Payments.
+* Improvement: Further improve the AJAX download search.
+* Fix: Improved reliablity with the PayPal API.
+* Fix: Some plugins could conflict with the login URL filter to customize the login page.
+* Fix: It is now possible to deselect a page in the settings after it's been set.
+* Fix: All documentation links have been updated to use the new locations.
+* Fix: Some passwords could not be validated when using the login form on the checkout page.
+* Fix: The orders export did not allow only orders with a specific status to be exported.
+
 = 3.1.0.5, January 25, 2023 =
 * Improvement: New customer report tiles now only count customers with purchases.
 * Improvement: The email address field at checkout now adheres to the database schema and limits to 100 characters.

--- a/src/Downloads/Search.php
+++ b/src/Downloads/Search.php
@@ -180,7 +180,7 @@ class Search {
 		global $wpdb;
 		$query = '';
 		foreach ( $terms as $term ) {
-			$operator = empty( $query ) ? '' : ' OR ';
+			$operator = empty( $query ) ? '' : ' AND ';
 			$term     = $wpdb->esc_like( $term );
 			$query   .= "{$operator}{$wpdb->posts}.post_title LIKE '%{$term}%'";
 		}

--- a/tests/tests-login-register.php
+++ b/tests/tests-login-register.php
@@ -286,4 +286,41 @@ class Tests_Login_Register extends EDD_UnitTestCase {
 		$this->assertTrue( 0 === strpos( edd_get_file_download_login_redirect( array( 'foo' => 'bar' ) ), get_permalink( $login_redirect_page_id ) ) );
 		edd_delete_option( 'login_redirect_page' );
 	}
+
+	public function test_login_uri_with_block_returns_uri() {
+		if ( version_compare( get_bloginfo( 'version' ), '5.8', '<' ) ) {
+			$this->markTestSkipped( 'This only runs if blocks are loaded.' );
+		}
+		$login_page_id = wp_insert_post(
+			array(
+				'post_title'   => 'Login Page',
+				'post_status'  => 'publish',
+				'post_type'    => 'page',
+				'post_content' => '<!-- wp:edd/login /-->',
+			)
+		);
+		edd_update_option( 'login_page', $login_page_id );
+
+		$this->assertContains( get_permalink( $login_page_id ), edd_get_login_page_uri() );
+
+		edd_delete_option( 'login_page' );
+		wp_delete_post( $login_page_id );
+	}
+
+	public function test_login_uri_without_block_returns_false() {
+		$login_page_id = wp_insert_post(
+			array(
+				'post_title'   => 'Login Page',
+				'post_status'  => 'publish',
+				'post_type'    => 'page',
+				'post_content' => '<!-- wp:shortcode -->[edd_login]<!-- /wp:shortcode -->',
+			)
+		);
+		edd_update_option( 'login_page', $login_page_id );
+
+		$this->assertFalse( edd_get_login_page_uri() );
+
+		edd_delete_option( 'login_page' );
+		wp_delete_post( $login_page_id );
+	}
 }


### PR DESCRIPTION
## Changelog:
* Improvement: Have the PayPal IPN backup include the order date in the information sent to Recurring.
* Improvement: Further improve the AJAX download search.
* Fix: Further work to create specific user-agent to send in PayPal requests to avoid 403/400 errors.
* Fix: Some plugins could conflict with the login URL filter to customize the login page.
* Fix: It is now possible to deselect a page in the settings after it's been set.
* Fix: All documentation links have been updated to use the new locations.
* Fix: Some passwords could not be validated when using the login form on the checkout page.
* Fix: The orders export did not allow only orders with a specific status to be exported.