### PR TITLE
Change the priority when registering the default EDD metaboxes

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -43,7 +43,7 @@ function edd_add_download_meta_box() {
 		}
 	}
 }
-add_action( 'add_meta_boxes', 'edd_add_download_meta_box' );
+add_action( 'add_meta_boxes', 'edd_add_download_meta_box', 9 );
 
 /**
  * Returns default EDD Download meta fields.


### PR DESCRIPTION
Currently AIOSEO registers it's metabox first (A comes before E) at the same priority (10) and position (high). The quickest and easiest fix is for EDD to enter the filter hook race first using a lower priority (9).

We could make this change in AIOSEO, but it's better that EDD does this for 2 reasons:
1. AIOSEO attempts to be as high in the list as possible (within reason) and any change we make would affect this.
2. EDD should try to always be at the top inside the downloads screen above any other plugin and the change here would help with any other plugin conflicts.
