### PR TITLE
edd_is_cart_saved logic correction - Fix #9658

### DIFF
--- a/includes/cart/class-edd-cart.php
+++ b/includes/cart/class-edd-cart.php
@@ -1349,7 +1349,7 @@ class EDD_Cart {
 				return false;
 			}
 
-			if ( $saved_cart === EDD()->session->get( 'edd_cart' ) ) {
+			if ( $saved_cart !== EDD()->session->get( 'edd_cart' ) ) {
 				return false;
 			}
 


### PR DESCRIPTION
Revised the logic to correctly compare the users saved cart data to the session cart data and reply false if they don't match when testing `edd_is_cart_saved`

Fixes #9658

_Please do not submit PRs with minified CSS or JS files. This is managed at the time of release by the Core Team_
