### PR TITLE
Don't assign default type in Downloads' "Files" metabox

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -292,7 +292,7 @@ function edd_render_files_meta_box() {
 	 * Output the files fields
 	 * @since 1.9
 	 */
-	do_action( 'edd_meta_box_files_fields', get_the_ID(), 'default' );
+	do_action( 'edd_meta_box_files_fields', get_the_ID(), '' );
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/awesomemotive/easy-digital-downloads/issues/9682


