### PR TITLE
Fix key mismatch between pricing variations and downloads array at `get_variable_priced_bundled_downloads()`

### DIFF
--- a/includes/class-edd-download.php
+++ b/includes/class-edd-download.php
@@ -602,8 +602,8 @@ class EDD_Download {
 		$price_assignments = $price_assignments[0];
 
 		foreach ( $price_assignments as $key => $value ) {
-			if ( isset( $bundled_downloads[ $key ] ) && ( $value == $price_id || $value == 'all' ) ) {
-				$downloads[] = $bundled_downloads[ $key ];
+			if ( isset( $bundled_downloads[ $key - 1 ] ) && ( $value == $price_id || $value == 'all' ) ) {
+				$downloads[] = $bundled_downloads[ $key - 1 ];
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/awesomemotive/easy-digital-downloads/issues/9688
