### PR TITLE
Trigger JS event on checkout success.

### DIFF
--- a/assets/js/frontend/edd-ajax.js
+++ b/assets/js/frontend/edd-ajax.js
@@ -403,6 +403,8 @@ jQuery( document ).ready( function( $ ) {
 				$( '.edd_errors' ).remove();
 				$( '.edd-error' ).hide();
 				$( eddPurchaseform ).submit();
+
+				$( document.body ).trigger( 'edd_checkout_success', [ data ] );
 			} else {
 				$( '#edd-purchase-button' ).val( complete_purchase_val );
 				$( '.edd-loading-ajax' ).remove();


### PR DESCRIPTION
Fixes #

Proposed Changes:
1. There is a JS event triggered in case of checkout failure `edd_checkout_error`, but not the one for successful purchase. It will be very handy to have one, to align with other plugins that need to listen to this action as well, like in our case for custom tracking.

_Please do not submit PRs with minified CSS or JS files. This is managed at the time of release by the Core Team_
