### PR TITLE
Updated: hook

### DIFF
--- a/includes/admin/downloads/dashboard-columns.php
+++ b/includes/admin/downloads/dashboard-columns.php
@@ -106,7 +106,7 @@ function edd_render_download_columns( $column_name, $post_id ) {
 			break;
 	}
 }
-add_action( 'manage_posts_custom_column', 'edd_render_download_columns', 10, 2 );
+add_action( 'manage_download_posts_custom_column', 'edd_render_download_columns', 10, 2 );
 
 /**
  * Registers the sortable columns in the list table


### PR DESCRIPTION
Updated: Changed the hook `manage_posts_custom_column` to `manage_download_posts_custom_column`

Fixes #9746

This update will support both the default case and hierarchical post types for the `download`.