### PR TITLE
Add error handling for get_terms()

### DIFF
--- a/includes/admin/downloads/dashboard-columns.php
+++ b/includes/admin/downloads/dashboard-columns.php
@@ -237,7 +237,7 @@ function edd_add_download_filters() {
 	);
 
 	$categories = get_terms( $category_args );
-	if ( ! empty( $categories ) ) {
+	if ( ! is_wp_error( $categories ) && ! empty( $categories ) ) {
 		$category_labels = edd_get_taxonomy_labels( 'download_category' );
 
 		$options    = array();

--- a/includes/admin/reporting/class-categories-reports-table.php
+++ b/includes/admin/reporting/class-categories-reports-table.php
@@ -158,122 +158,124 @@ class EDD_Categories_Reports_Table extends List_Table {
 				'hide_empty'   => false
 			) );
 
-			foreach ( $categories as $category ) {
+            if ( ! is_wp_error( $categories ) && ! empty( $categories ) ) {
+                foreach ( $categories as $category ) {
 
-				$category_slugs = array( $category->slug );
-				$child_terms    = get_terms( 'download_category', array(
-					'parent'       => $category->term_id,
-					'hierarchical' => 0
-				) );
+                    $category_slugs = array( $category->slug );
+                    $child_terms    = get_terms( 'download_category', array(
+                        'parent'       => $category->term_id,
+                        'hierarchical' => 0
+                    ) );
 
-				if ( ! empty( $child_terms ) ) {
-					foreach ( $child_terms as $child_term ) {
-						$category_slugs[] = $child_term->slug;
-					}
-				}
+                    if ( ! empty( $child_terms ) ) {
+                        foreach ( $child_terms as $child_term ) {
+                            $category_slugs[] = $child_term->slug;
+                        }
+                    }
 
-				$downloads = get_posts( array(
-					'post_type'      => 'download',
-					'posts_per_page' => -1,
-					'fields'         => 'ids',
-					'tax_query'      => array(
-						array(
-							'taxonomy' => 'download_category',
-							'field'    => 'slug',
-							'terms'    => $category_slugs
-						)
-					)
-				) );
+                    $downloads = get_posts( array(
+                        'post_type'      => 'download',
+                        'posts_per_page' => -1,
+                        'fields'         => 'ids',
+                        'tax_query'      => array(
+                            array(
+                                'taxonomy' => 'download_category',
+                                'field'    => 'slug',
+                                'terms'    => $category_slugs
+                            )
+                        )
+                    ) );
 
-				$sales     = $avg_sales    = 0;
-				$earnings  = $avg_earnings = 0.00;
+                    $sales     = $avg_sales    = 0;
+                    $earnings  = $avg_earnings = 0.00;
 
-				foreach ( $downloads as $download ) {
-					$current_sales    = EDD()->payment_stats->get_sales( $download, $start_date, $end_date );
-					$current_earnings = EDD()->payment_stats->get_earnings( $download, $start_date, $end_date, $include_taxes );
+                    foreach ( $downloads as $download ) {
+                        $current_sales    = EDD()->payment_stats->get_sales( $download, $start_date, $end_date );
+                        $current_earnings = EDD()->payment_stats->get_earnings( $download, $start_date, $end_date, $include_taxes );
 
-					$current_average_sales = edd_get_average_monthly_download_sales( $download );
-					$current_average_earnings = edd_get_average_monthly_download_earnings( $download );
+                        $current_average_sales = edd_get_average_monthly_download_sales( $download );
+                        $current_average_earnings = edd_get_average_monthly_download_earnings( $download );
 
-					$sales        += $current_sales;
-					$earnings     += $current_earnings;
-					$avg_sales    += $current_average_sales;
-					$avg_earnings += $current_average_earnings;
-				}
+                        $sales        += $current_sales;
+                        $earnings     += $current_earnings;
+                        $avg_sales    += $current_average_sales;
+                        $avg_earnings += $current_average_earnings;
+                    }
 
-				$avg_earnings = round( $avg_earnings, edd_currency_decimal_filter() );
-				if ( ! empty( $avg_earnings ) && $avg_sales < 1 ) {
-					$avg_sales = __( 'Less than 1', 'easy-digital-downloads' );
-				} else {
-					$avg_sales = round( edd_format_amount( $avg_sales, false ) );
-				}
+                    $avg_earnings = round( $avg_earnings, edd_currency_decimal_filter() );
+                    if ( ! empty( $avg_earnings ) && $avg_sales < 1 ) {
+                        $avg_sales = __( 'Less than 1', 'easy-digital-downloads' );
+                    } else {
+                        $avg_sales = round( edd_format_amount( $avg_sales, false ) );
+                    }
 
-				$reports_data[] = array(
-					'ID'                 => $category->term_id,
-					'label'              => $category->name,
-					'total_sales'        => edd_format_amount( $sales, false ),
-					'total_sales_raw'    => $sales,
-					'total_earnings'     => edd_currency_filter( edd_format_amount( $earnings ) ),
-					'total_earnings_raw' => $earnings,
-					'avg_sales'          => $avg_sales,
-					'avg_earnings'       => edd_currency_filter( edd_format_amount( $avg_earnings ) ),
-					'is_child'           => false,
-				);
+                    $reports_data[] = array(
+                        'ID'                 => $category->term_id,
+                        'label'              => $category->name,
+                        'total_sales'        => edd_format_amount( $sales, false ),
+                        'total_sales_raw'    => $sales,
+                        'total_earnings'     => edd_currency_filter( edd_format_amount( $earnings ) ),
+                        'total_earnings_raw' => $earnings,
+                        'avg_sales'          => $avg_sales,
+                        'avg_earnings'       => edd_currency_filter( edd_format_amount( $avg_earnings ) ),
+                        'is_child'           => false,
+                    );
 
-				if ( ! empty( $child_terms ) ) {
-					foreach ( $child_terms as $child_term ) {
-						$child_downloads = get_posts( array(
-							'post_type'      => 'download',
-							'posts_per_page' => -1,
-							'fields'         => 'ids',
-							'tax_query'      => array(
-								array(
-									'taxonomy' => 'download_category',
-									'field'    => 'slug',
-									'terms'    => $child_term->slug
-								)
-							)
-						) );
+                    if ( ! empty( $child_terms ) ) {
+                        foreach ( $child_terms as $child_term ) {
+                            $child_downloads = get_posts( array(
+                                'post_type'      => 'download',
+                                'posts_per_page' => -1,
+                                'fields'         => 'ids',
+                                'tax_query'      => array(
+                                    array(
+                                        'taxonomy' => 'download_category',
+                                        'field'    => 'slug',
+                                        'terms'    => $child_term->slug
+                                    )
+                                )
+                            ) );
 
-						$child_sales     = $child_avg_sales    = 0;
-						$child_earnings  = $child_avg_earnings = 0.00;
+                            $child_sales     = $child_avg_sales    = 0;
+                            $child_earnings  = $child_avg_earnings = 0.00;
 
-						foreach ( $child_downloads as $child_download ) {
-							$current_average_sales    = $current_sales    = EDD()->payment_stats->get_sales( $child_download, $start_date, $end_date );
-							$current_average_earnings = $current_earnings = EDD()->payment_stats->get_earnings( $child_download, $start_date, $end_date );
+                            foreach ( $child_downloads as $child_download ) {
+                                $current_average_sales    = $current_sales    = EDD()->payment_stats->get_sales( $child_download, $start_date, $end_date );
+                                $current_average_earnings = $current_earnings = EDD()->payment_stats->get_earnings( $child_download, $start_date, $end_date );
 
-							$release_date = get_post_field( 'post_date', $child_download );
-							$diff         = abs( current_time( 'timestamp' ) - strtotime( $release_date ) );
-							$months       = floor( $diff / ( 30 * 60 * 60 * 24 ) ); // Number of months since publication
+                                $release_date = get_post_field( 'post_date', $child_download );
+                                $diff         = abs( current_time( 'timestamp' ) - strtotime( $release_date ) );
+                                $months       = floor( $diff / ( 30 * 60 * 60 * 24 ) ); // Number of months since publication
 
-							if ( $months > 0 ) {
-								$current_average_sales    = ( $current_sales / $months );
-								$current_average_earnings = ( $current_earnings / $months );
-							}
+                                if ( $months > 0 ) {
+                                    $current_average_sales    = ( $current_sales / $months );
+                                    $current_average_earnings = ( $current_earnings / $months );
+                                }
 
-							$child_sales        += $current_sales;
-							$child_earnings     += $current_earnings;
-							$child_avg_sales    += $current_average_sales;
-							$child_avg_earnings += $current_average_earnings;
-						}
+                                $child_sales        += $current_sales;
+                                $child_earnings     += $current_earnings;
+                                $child_avg_sales    += $current_average_sales;
+                                $child_avg_earnings += $current_average_earnings;
+                            }
 
-						$child_avg_sales    = round( $child_avg_sales / count( $child_downloads ) );
-						$child_avg_earnings = round( $child_avg_earnings / count( $child_downloads ), edd_currency_decimal_filter() );
+                            $child_avg_sales    = round( $child_avg_sales / count( $child_downloads ) );
+                            $child_avg_earnings = round( $child_avg_earnings / count( $child_downloads ), edd_currency_decimal_filter() );
 
-						$reports_data[] = array(
-							'ID'                 => $child_term->term_id,
-							'label'              => '&#8212; ' . $child_term->name,
-							'total_sales'        => edd_format_amount( $child_sales, false ),
-							'total_sales_raw'    => $child_sales,
-							'total_earnings'     => edd_currency_filter( edd_format_amount( $child_earnings ) ),
-							'total_earnings_raw' => $child_earnings,
-							'avg_sales'          => edd_format_amount( $child_avg_sales, false ),
-							'avg_earnings'       => edd_currency_filter( edd_format_amount( $child_avg_earnings ) ),
-							'is_child'           => true
-						);
-					}
-				}
-			}
+                            $reports_data[] = array(
+                                'ID'                 => $child_term->term_id,
+                                'label'              => '&#8212; ' . $child_term->name,
+                                'total_sales'        => edd_format_amount( $child_sales, false ),
+                                'total_sales_raw'    => $child_sales,
+                                'total_earnings'     => edd_currency_filter( edd_format_amount( $child_earnings ) ),
+                                'total_earnings_raw' => $child_earnings,
+                                'avg_sales'          => edd_format_amount( $child_avg_sales, false ),
+                                'avg_earnings'       => edd_currency_filter( edd_format_amount( $child_avg_earnings ) ),
+                                'is_child'           => true
+                            );
+                        }
+                    }
+                }
+		    }
 		}
 
 		return $reports_data;

--- a/includes/admin/reporting/class-download-reports-table.php
+++ b/includes/admin/reporting/class-download-reports-table.php
@@ -169,7 +169,9 @@ class EDD_Download_Reports_Table extends List_Table {
 	 * @return void
 	 */
 	public function category_filter() {
-		if ( get_terms( 'download_category' ) ) {
+		$categories = get_terms( 'download_category' );
+
+		if ( ! is_wp_error( $categories ) && ! empty( $categories ) ) {
 			echo EDD()->html->category_dropdown( 'category', $this->get_category() );
 		}
 	}

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -683,7 +683,7 @@ function edd_ajax_download_category_search() {
 
 	$categories_found = get_terms( $category_args );
 
-	if ( ! empty( $categories_found ) ) {
+	if ( ! is_wp_error( $categories_found ) && ! empty( $categories_found ) ) {
 		foreach ( $categories_found as $category ) {
 			$results[] = array(
 				'id'   => $category->slug,

--- a/src/Downloads/Services.php
+++ b/src/Downloads/Services.php
@@ -159,8 +159,11 @@ class Services implements SubscriberInterface {
 
 		$options = array();
 		$terms   = get_terms( 'download_category', apply_filters( 'edd_das_get_terms', $args ) );
-		foreach ( $terms as $term ) {
-			$options[ $term->term_id ] = $term->name;
+
+		if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+			foreach ( $terms as $term ) {
+				$options[ $term->term_id ] = $term->name;
+			}
 		}
 
 		return $options;

--- a/src/HTML/CategorySelect.php
+++ b/src/HTML/CategorySelect.php
@@ -86,8 +86,10 @@ class CategorySelect {
 		$categories = get_terms( $this->get_category_args() );
 		$options    = array();
 
-		foreach ( $categories as $category ) {
-			$options[ absint( $category->term_id ) ] = esc_html( $category->name );
+		if ( ! is_wp_error( $categories ) && ! empty( $categories ) ) {
+			foreach ( $categories as $category ) {
+				$options[ absint( $category->term_id ) ] = esc_html( $category->name );
+			}
 		}
 
 		return $options;

--- a/src/HTML/Elements.php
+++ b/src/HTML/Elements.php
@@ -340,8 +340,10 @@ class Elements {
 		$categories = get_terms( 'download_category', apply_filters( 'edd_category_dropdown', array() ) );
 		$options    = array();
 
-		foreach ( $categories as $category ) {
-			$options[ absint( $category->term_id ) ] = esc_html( $category->name );
+		if ( ! is_wp_error( $categories ) && ! empty( $categories ) ) {
+			foreach ( $categories as $category ) {
+				$options[ absint( $category->term_id ) ] = esc_html( $category->name );
+			}
 		}
 
 		$category_labels = edd_get_taxonomy_labels( 'download_category' );


### PR DESCRIPTION
Added a check to ensure `get_terms()` result is not a WP_Error object before proceeding.