### PR TITLE
Comments added for Translators in multiple files

### DIFF
--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -298,6 +298,7 @@ class EDD_SL_Plugin_Updater {
 		} elseif ( ! empty( $changelog_link ) ) {
 			echo ' ';
 			printf(
+				// Translators: %1$s is the link to view the version details, %2$s is the new version number, %3$s closes the version details link, %4$s is the link to update the plugin, %5$s closes the update link.
 				__( '%1$sView version %2$s details%3$s or %4$supdate now%5$s.', 'easy-digital-downloads' ),
 				'<a target="_blank" class="thickbox open-plugin-details-modal" href="' . esc_url( $changelog_link ) . '">',
 				esc_html( $update_cache->response[ $this->name ]->new_version ),

--- a/includes/api/class-edd-api-v2.php
+++ b/includes/api/class-edd-api-v2.php
@@ -174,6 +174,7 @@ class EDD_API_V2 extends EDD_API_V1 {
 				$products['products'][0] = $this->get_product_data( $product_info );
 
 			} else {
+				// Translators: %s is the product name.
 				$error['error'] = sprintf( __( 'Product %s not found!', 'easy-digital-downloads' ), $args['product'] );
 				return $error;
 			}

--- a/includes/class-edd-download.php
+++ b/includes/class-edd-download.php
@@ -374,6 +374,7 @@ class EDD_Download {
 		if ( method_exists( $this, "get_{$key}" ) ) {
 			return call_user_func( array( $this, "get_{$key}" ) );
 		} else {
+			// Translators: %s is the name of the property that could not be retrieved.
 			return new WP_Error( 'edd-download-invalid-property', sprintf( __( 'Can\'t get property %s', 'easy-digital-downloads' ), $key ) );
 		}
 	}

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -1478,6 +1478,7 @@ function display_products_filter() {
 		'variations'       => true,
 		'selected'         => empty( $products ) ? 0 : $products,
 		'show_option_none' => false,
+		// Translators: %s represents the plural label for the items in the context of Easy Digital Downloads.
 		'show_option_all'  => sprintf( __( 'All %s', 'easy-digital-downloads' ), edd_get_label_plural() ),
 	) ); ?>
 

--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -363,6 +363,7 @@ class EDD_Product_Details_Widget extends WP_Widget {
 	public function form( $instance ) {
 		// Set up some default widget settings.
 		$defaults = array(
+			// Translators: %s is the singular label of the product/item.
 			'title'           => sprintf( __( '%s Details', 'easy-digital-downloads' ), edd_get_label_singular() ),
 			'display_type'    => 'current',
 			'download_id'     => false,


### PR DESCRIPTION
Adds #

Proposed Changes:
1. Comments added for Translators in "includes/widgets.php"
2. Comments added for Translators in "includes/class-edd-download.php"
3. Comments added for Translators in "includes/api/class-edd-api-v2.php"
4. Comments added for Translators in "includes/reports/reports-functions.php"
5. Comments added for Translators in "includes/EDD_SL_Plugin_Updater.php"





