### PR TITLE
Update CONTRIBUTING.md with correct branch name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ __Please Note:__ GitHub is for bug reports and contributions only - if you have 
   * Ensure you stick to the [WordPress Coding Standards](https://codex.wordpress.org/WordPress_Coding_Standards)
 * When committing, reference your issue (if present) and include a note about the fix
 * If possible, and if applicable, please also add/update unit tests for your changes
-* Push the changes to your fork and submit a pull request to the 'master' branch of the EDD repository
+* Push the changes to your fork and submit a pull request to the 'main' branch of the EDD repository
 
 ## Code Documentation
 


### PR DESCRIPTION
It looks like the `master` branch is abandoned as it hasn't been updated in years.

All the development is done in `main` now, so let the CONTRIBUTING.md mention the `main` branch.