### PR TITLE
Release 3.3.5.2

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -5,7 +5,7 @@
  * Description: The easiest way to sell digital products with WordPress.
  * Author: Easy Digital Downloads
  * Author URI: https://easydigitaldownloads.com
- * Version: 3.3.5.1
+ * Version: 3.3.5.2
  * Text Domain: easy-digital-downloads
  * Domain Path: /languages
  * Requires at least: 6.0
@@ -27,7 +27,7 @@
  * @package EDD
  * @category Core
  * @author Easy Digital Downloads
- * @version 3.3.5.1
+ * @version 3.3.5.2
  */
 
 // Exit if accessed directly.

--- a/includes/class-easy-digital-downloads.php
+++ b/includes/class-easy-digital-downloads.php
@@ -364,7 +364,7 @@ if ( ! class_exists( 'Easy_Digital_Downloads' ) ) :
 
 			// Plugin version.
 			if ( ! defined( 'EDD_VERSION' ) ) {
-				define( 'EDD_VERSION', '3.3.5.1' );
+				define( 'EDD_VERSION', '3.3.5.2' );
 			}
 
 			// Make sure CAL_GREGORIAN is defined.

--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -746,8 +746,8 @@ function edd_register_and_login_new_user( $user_data = array() ) {
 		'user_login' => '',
 		'user_pass'  => '',
 		'user_email' => '',
-		'first_name' => '',
-		'last_name'  => '',
+		'first_name' => isset( $user_data['user_first'] ) ? $user_data['user_first'] : '',
+		'last_name'  => isset( $user_data['user_last'] ) ? $user_data['user_last'] : '',
 		'role'       => get_option( 'default_role' ),
 	);
 	$user_args = wp_parse_args( $user_data, $defaults );

--- a/languages/easy-digital-downloads.pot
+++ b/languages/easy-digital-downloads.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the Easy Digital Downloads plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Digital Downloads 3.3.5.1\n"
+"Project-Id-Version: Easy Digital Downloads 3.3.5.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/easy-digital-downloads-public\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-11-14T23:08:35+00:00\n"
+"POT-Creation-Date: 2024-11-22T09:18:08+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: ecommerce, payments, sell, digital store, stripe
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable Tag: 3.3.5.1
+Stable Tag: 3.3.5.2
 License: GPLv2 or later
 
 The #1 eCommerce plugin to sell digital products & subscriptions. Accept credit card payments with Stripe & PayPal and start your store today.
@@ -237,6 +237,11 @@ Check out some of our popular posts for actionable advice for running your busin
 8. Checkout Form Block - Default Theme
 
 == Changelog ==
+
+= 3.3.5.2 =
+* Checkout: Fixed a user's first/last name not saving to their WordPress account when registering during checkout.
+* Checkout: Fixed purchase data being sent to some gateways which process credit cards from form data.
+
 = 3.3.5.1 =
 * Stripe: Fixed issues with displaying and saving Stripe settings.
 

--- a/src/Sessions/PurchaseData.php
+++ b/src/Sessions/PurchaseData.php
@@ -109,6 +109,10 @@ class PurchaseData {
 
 		edd_set_purchase_session( $purchase_data );
 
+		// Send the card info and post data back to the purchase data, even though it's not stored in the session.
+		$purchase_data['card_info'] = $valid_data['cc_info'] ?? array();
+		$purchase_data['post_data'] = $_POST;
+
 		return $purchase_data;
 	}
 

--- a/tests/sessions/tests-purchase-data.php
+++ b/tests/sessions/tests-purchase-data.php
@@ -31,6 +31,8 @@ class PurchaseData extends EDD_UnitTestCase {
 			'edd_email' => 'john@doe.example',
 		);
 		$purchase_session = \EDD\Sessions\PurchaseData::start( false );
+		unset( $purchase_session['card_info'] );
+		unset( $purchase_session['post_data'] );
 
 		$this->assertEquals( $user_id, $purchase_session['user_info']['id'] );
 		$this->assertEquals( $_POST['edd_email'], $purchase_session['user_info']['email'] );
@@ -48,6 +50,8 @@ class PurchaseData extends EDD_UnitTestCase {
 		);
 
 		$purchase_session = \EDD\Sessions\PurchaseData::start();
+		unset( $purchase_session['card_info'] );
+		unset( $purchase_session['post_data'] );
 
 		$this->assertEmpty( $purchase_session['user_info']['id'] );
 		$this->assertEquals( $_POST['edd_email'], $purchase_session['user_info']['email'] );


### PR DESCRIPTION
Changelog:
* Checkout: Fixed a user's first/last name not saving to their WordPress account when registering during checkout.
* Checkout: Fixed purchase data being sent to some gateways which process credit cards from form data.