### PR TITLE
Dynamically switch the Stripe elements mode using a fitler

### DIFF
--- a/includes/gateways/stripe/includes/elements/functions.php
+++ b/includes/gateways/stripe/includes/elements/functions.php
@@ -57,7 +57,7 @@ function edds_get_elements_mode() {
 		return 'card-elements';
 	}
 
-	return edd_get_option( 'stripe_elements_mode', $default );
+	return apply_filters( 'edds_elements_mode', edd_get_option( 'stripe_elements_mode', $default ) );
 }
 
 /**


### PR DESCRIPTION
Proposed Changes:
1. Add a filter to edds_get_elements_mode() so that the user can hook in and dynamically switch the Stripe elements mode. This may be needed if there are multiple subscriptions in the cart or a subscription and a non-subscription and the user is using the payment elements mode but wants to switch to the card elements mode to support such scenarios.
